### PR TITLE
Patched in options to disabled RTOS handeling of main client and addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To start using mender-mcu-client, we recommend that you begin with one of the ex
 ## Dependencies
 
 The mender-mcu-client library tries to be very light in order to be used on most projects wanted to have over-the-air updates. The library mainly rely on the presence of an RTOS to have thread, semaphore and memory allocation support.
+However if user wishes there are Kconfig flags to control which parts are handled by RTOS and which the user handles themselves.
 
 Additionally, a TCP/IP interface is required because communications are done using HTTPS protocol, however it is possible to have an abstraction for example using a WiFi module connected to the MCU with a serial interface and using AT commands.
 

--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -36,10 +36,17 @@ menu "Mender General Options"
         help
             Set the Mender server Tenant Token, to be used with https://hosted.mender.io. Retrieve it from the "Organization and billing" settings of your account.
 
+    config MENDER_CLIENT_DISABLE_RTOS
+        bool "Mender client Disable RTOS polling"
+			  default n
+        help
+          Disable RTOS polling in the Mender client. This option is useful if you want to use the Mender client in a non-RTOS application.
+
     config MENDER_CLIENT_AUTHENTICATION_POLL_INTERVAL
         int "Mender client Authentication poll interval (seconds)"
         range 0 3600
         default 600
+				depends on !MENDER_CLIENT_DISABLE_RTOS
         help
             Interval used to periodically try to authenticate to the Mender server until it succeeds.
 
@@ -47,6 +54,7 @@ menu "Mender General Options"
         int "Mender client Update poll interval (seconds)"
         range 0 86400
         default 1800
+				depends on !MENDER_CLIENT_DISABLE_RTOS
         help
             Interval used to periodically check for new deployments on the Mender server.
 
@@ -88,6 +96,12 @@ menu "Mender Addons Options"
 
     if MENDER_CLIENT_ADD_ON_CONFIGURE
 
+        config MENDER_CLIENT_CONFIGURE_DISABLE_RTOS
+            bool "Mender client Disable RTOS polling for Configure addon"
+            default n
+            help
+               Disable RTOS polling in the Mender Configure addon. This option is useful if you want to use the Mender client in a non-RTOS application.
+
         config MENDER_CLIENT_CONFIGURE_STORAGE
             bool "Mender client Configure storage"
             default y
@@ -98,6 +112,7 @@ menu "Mender Addons Options"
             int "Mender client Configure refresh interval (seconds)"
             range 0 86400
             default 28800
+						depends on !MENDER_CLIENT_CONFIGURE_DISABLE_RTOS
             help
                 Interval used to periodically refresh configuration to/from the Mender server.
 
@@ -112,12 +127,20 @@ menu "Mender Addons Options"
 
     if MENDER_CLIENT_ADD_ON_INVENTORY
 
+        config MENDER_CLIENT_INVENTORY_DISABLE_RTOS
+            bool "Mender client Disable RTOS polling for Inventory addon"
+            default n
+            help
+              Disable RTOS polling in the Mender Inventory addon. This option is useful if you want to use the Mender client in a non-RTOS application.
+
         config MENDER_CLIENT_INVENTORY_REFRESH_INTERVAL
             int "Mender client Inventory refresh interval (seconds)"
             range 0 86400
+						depends on !MENDER_CLIENT_INVENTORY_DISABLE_RTOS
             default 28800
             help
                 Interval used to periodically send inventory to the Mender server.
+
 
     endif
 
@@ -130,9 +153,16 @@ menu "Mender Addons Options"
 
     if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
+        config MENDER_CLIENT_TROUBLESHOOT_DISABLE_RTOS
+            bool "Mender client Disable RTOS polling for Troubleshoot addon"
+            default n
+            help
+                Disable RTOS polling in the Mender Troubleshoot addon. This option is useful if you want to use the Mender client in a non-RTOS application.
+
         config MENDER_CLIENT_TROUBLESHOOT_HEALTHCHECK_INTERVAL
             int "Mender client Troubleshoot healthcheck interval (seconds)"
             range 0 60
+						depends on !MENDER_CLIENT_TROUBLESHOOT_DISABLE_RTOS
             default 30
             help
                 Interval used to periodically perform healthcheck with the Mender server.

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -77,6 +77,28 @@ mender_err_t mender_client_init(mender_client_config_t *config, mender_client_ca
  */
 mender_err_t mender_client_exit(void);
 
+/**
+ * @brief Mender client initialization work function
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_initialization_routine(void);
+
+
+
+/**
+ * @brief Mender client authentication work function
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_authentication_routine(void);
+
+/**
+ * @brief Mender client update work function
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_update_routine(void);
+
+
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/mender-configure.h
+++ b/include/mender-configure.h
@@ -60,11 +60,13 @@ typedef struct {
  */
 mender_err_t mender_configure_init(mender_configure_config_t *config, mender_configure_callbacks_t *callbacks);
 
+#ifdef CONFIG_MENDER_CLIENT_CONFIGURE_DISABLE_RTOS
 /**
  * @brief Activate mender configure add-on
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_configure_activate(void);
+#endif /* CONFIG_MENDER_CLIENT_CONFIGURE_DISABLE_RTOS */
 
 /**
  * @brief Get mender configuration
@@ -85,6 +87,13 @@ mender_err_t mender_configure_set(mender_keystore_t *configuration);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_configure_exit(void);
+
+/**
+ * @brief Mender configure work function
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_configure_routine(void);
+
 
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE */
 

--- a/include/mender-inventory.h
+++ b/include/mender-inventory.h
@@ -50,11 +50,13 @@ typedef struct {
  */
 mender_err_t mender_inventory_init(mender_inventory_config_t *config);
 
+#ifndef CONFIG_MENDER_CLIENT_INVENTORY_DISABLE_RTOS
 /**
  * @brief Activate mender inventory add-on
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_inventory_activate(void);
+#endif /* CONFIG_MENDER_CLIENT_INVENTORY_DISABLE_RTOS */
 
 /**
  * @brief Set mender inventory
@@ -68,6 +70,13 @@ mender_err_t mender_inventory_set(mender_keystore_t *inventory);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_inventory_exit(void);
+
+/**
+ * @brief Mender inventory work function
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_inventory_routine(void);
+
 
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_INVENTORY */
 

--- a/include/mender-troubleshoot.h
+++ b/include/mender-troubleshoot.h
@@ -89,6 +89,12 @@ mender_err_t mender_troubleshoot_shell_print(uint8_t *data, size_t length);
  */
 mender_err_t mender_troubleshoot_exit(void);
 
+/**
+ * @brief Mender troubleshoot healthcheck work function
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_troubleshoot_healthcheck_routine(void);
+
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT */
 
 #ifdef __cplusplus

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -58,24 +58,33 @@ if MENDER_MCU_CLIENT
             help
                 Set the Mender server host URL to be used on the device.
 
-        config MENDER_SERVER_TENANT_TOKEN
+       config MENDER_SERVER_TENANT_TOKEN
             string "Mender server Tenant Token"
             help
                 Set the Mender server Tenant Token, to be used with https://hosted.mender.io. Retrieve it from the "Organization and billing" settings of your account.
 
-        config MENDER_CLIENT_AUTHENTICATION_POLL_INTERVAL
+       config MENDER_CLIENT_DISABLE_RTOS
+            bool "Mender client Disable RTOS polling"
+     		    default n
+            help
+                Disable RTOS polling in the Mender client. This option is useful if you want to use the Mender client in a non-RTOS application.
+
+       config MENDER_CLIENT_AUTHENTICATION_POLL_INTERVAL
             int "Mender client Authentication poll interval (seconds)"
             range 0 3600
             default 600
+     			  depends on !MENDER_CLIENT_DISABLE_RTOS
             help
                 Interval used to periodically try to authenticate to the Mender server until it succeeds.
 
-        config MENDER_CLIENT_UPDATE_POLL_INTERVAL
+       config MENDER_CLIENT_UPDATE_POLL_INTERVAL
             int "Mender client Update poll interval (seconds)"
             range 0 86400
             default 1800
+     			  depends on !MENDER_CLIENT_DISABLE_RTOS
             help
                 Interval used to periodically check for new deployments on the Mender server.
+
 
         module = MENDER
         module-str = Log Level for mender
@@ -102,10 +111,17 @@ if MENDER_MCU_CLIENT
                     help
                         Activate this option to save the configuration from the Mender server in the storage area of the device.
 
+                config MENDER_CLIENT_CONFIGURE_DISABLE_RTOS
+                    bool "Mender client Disable RTOS polling for Configure addon"
+                    default n
+                    help
+                       Disable RTOS polling in the Mender Configure addon. This option is useful if you want to use the Mender client in a non-RTOS application.
+
                 config MENDER_CLIENT_CONFIGURE_REFRESH_INTERVAL
                     int "Mender client Configure refresh interval (seconds)"
                     range 0 86400
                     default 28800
+										depends on !MENDER_CLIENT_CONFIGURE_DISABLE_RTOS
                     help
                         Interval used to periodically refresh configuration to/from the Mender server.
 
@@ -123,10 +139,16 @@ if MENDER_MCU_CLIENT
                     It is particularly used to send artifact name and device type, and it permits to see the last check-in time of the device.
 
             if MENDER_CLIENT_ADD_ON_INVENTORY
+                config MENDER_CLIENT_INVENTORY_DISABLE_RTOS
+                    bool "Mender client Disable RTOS polling for Inventory addon"
+                    default n
+                    help
+                       Disable RTOS polling in the Mender Inventory addon. This option is useful if you want to use the Mender client in a non-RTOS application.
 
                 config MENDER_CLIENT_INVENTORY_REFRESH_INTERVAL
                     int "Mender client Inventory refresh interval (seconds)"
                     range 0 86400
+						        depends on !MENDER_CLIENT_INVENTORY_DISABLE_RTOS
                     default 28800
                     help
                         Interval used to periodically send inventory to the Mender server.
@@ -137,7 +159,13 @@ if MENDER_MCU_CLIENT
 
         menu "Mender Troubleshoot Addon Options"
 
-            config MENDER_CLIENT_ADD_ON_TROUBLESHOOT
+            config MENDER_CLIENT_TROUBLESHOOT_DISABLE_RTOS
+                bool "Mender client Disable RTOS polling for Troubleshoot addon"
+                default n
+                help
+                    Disable RTOS polling in the Mender Troubleshoot addon. This option is useful if you want to use the Mender client in a non-RTOS application.
+
+						config MENDER_CLIENT_ADD_ON_TROUBLESHOOT
                 bool "Mender client Troubleshoot"
                 default n
                 help
@@ -149,6 +177,7 @@ if MENDER_MCU_CLIENT
                 config MENDER_CLIENT_TROUBLESHOOT_HEALTHCHECK_INTERVAL
                     int "Mender client Troubleshoot healthcheck interval (seconds)"
                     range 0 60
+         		        depends on !MENDER_CLIENT_TROUBLESHOOT_DISABLE_RTOS
                     default 30
                     help
                         Interval used to periodically perform healthcheck with the Mender server.


### PR DESCRIPTION
Added option with Kconfig flags to disable RTOS. Also moved work_functions declarations to respective header files and renamed them to routines. Name work function didn't really fit with idea of them being not handled by RTOS. 

Verified functionality on esp32c6 and all runned as it should.