### PR TITLE
client: allow application triggering works

### DIFF
--- a/add-ons/src/mender-configure.c
+++ b/add-ons/src/mender-configure.c
@@ -214,6 +214,20 @@ END:
 }
 
 mender_err_t
+mender_configure_execute(void) {
+
+    mender_err_t ret;
+
+    /* Trigger execution of the work */
+    if (MENDER_OK != (ret = mender_rtos_work_execute(mender_configure_work_handle))) {
+        mender_log_error("Unable to trigger configure work");
+        return ret;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_configure_exit(void) {
 
     mender_err_t ret;

--- a/add-ons/src/mender-inventory.c
+++ b/add-ons/src/mender-inventory.c
@@ -139,6 +139,20 @@ END:
 }
 
 mender_err_t
+mender_inventory_execute(void) {
+
+    mender_err_t ret;
+
+    /* Trigger execution of the work */
+    if (MENDER_OK != (ret = mender_rtos_work_execute(mender_inventory_work_handle))) {
+        mender_log_error("Unable to trigger inventory work");
+        return ret;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_inventory_exit(void) {
 
     mender_err_t ret;

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -248,6 +248,20 @@ mender_client_init(mender_client_config_t *config, mender_client_callbacks_t *ca
 }
 
 mender_err_t
+mender_client_execute(void) {
+
+    mender_err_t ret;
+
+    /* Trigger execution of the work */
+    if (MENDER_OK != (ret = mender_rtos_work_execute(mender_client_work_handle))) {
+        mender_log_error("Unable to trigger update work");
+        return ret;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_client_exit(void) {
 
     /* Deactivate mender client work */

--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -42,6 +42,7 @@ menu "Mender General Options"
         default 600
         help
             Interval used to periodically try to authenticate to the Mender server until it succeeds.
+            Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
     config MENDER_CLIENT_UPDATE_POLL_INTERVAL
         int "Mender client Update poll interval (seconds)"
@@ -49,6 +50,7 @@ menu "Mender General Options"
         default 1800
         help
             Interval used to periodically check for new deployments on the Mender server.
+            Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
     choice MENDER_LOG_LEVEL
         bool "Mender client log verbosity"
@@ -100,6 +102,7 @@ menu "Mender Addons Options"
             default 28800
             help
                 Interval used to periodically refresh configuration to/from the Mender server.
+                Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
     endif
 
@@ -118,6 +121,7 @@ menu "Mender Addons Options"
             default 28800
             help
                 Interval used to periodically send inventory to the Mender server.
+                Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
     endif
 
@@ -132,7 +136,7 @@ menu "Mender Addons Options"
 
         config MENDER_CLIENT_TROUBLESHOOT_HEALTHCHECK_INTERVAL
             int "Mender client Troubleshoot healthcheck interval (seconds)"
-            range 0 60
+            range 10 60
             default 30
             help
                 Interval used to periodically perform healthcheck with the Mender server.

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -38,14 +38,14 @@ extern "C" {
  * @brief Mender client configuration
  */
 typedef struct {
-    char *   mac_address;                  /**< MAC address of the device */
-    char *   artifact_name;                /**< Artifact name */
-    char *   device_type;                  /**< Device type */
-    char *   host;                         /**< URL of the mender server */
-    char *   tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
-    uint32_t authentication_poll_interval; /**< Authentication poll interval, default is 60 seconds */
-    uint32_t update_poll_interval;         /**< Update poll interval, default is 1800 seconds */
-    bool     recommissioning;              /**< Used to force creation of new authentication keys */
+    char *  mac_address;                  /**< MAC address of the device */
+    char *  artifact_name;                /**< Artifact name */
+    char *  device_type;                  /**< Device type */
+    char *  host;                         /**< URL of the mender server */
+    char *  tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
+    int32_t authentication_poll_interval; /**< Authentication poll interval, default is 60 seconds, -1 permits to disable periodic execution */
+    int32_t update_poll_interval;         /**< Update poll interval, default is 1800 seconds, -1 permits to disable periodic execution */
+    bool    recommissioning;              /**< Used to force creation of new authentication keys */
 } mender_client_config_t;
 
 /**
@@ -70,6 +70,14 @@ typedef struct {
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_client_init(mender_client_config_t *config, mender_client_callbacks_t *callbacks);
+
+/**
+ * @brief Function used to trigger execution of the authentication and update work
+ * @note Calling this function is optional when the periodic execution of the work is configured
+ * @note It only permits to execute the work as soon as possible to synchronize updates
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_execute(void);
 
 /**
  * @brief Release mender client

--- a/include/mender-configure.h
+++ b/include/mender-configure.h
@@ -40,7 +40,7 @@ extern "C" {
  * @brief Mender configure configuration
  */
 typedef struct {
-    uint32_t refresh_interval; /**< Configure refresh interval, default is 28800 seconds */
+    int32_t refresh_interval; /**< Configure refresh interval, default is 28800 seconds, -1 permits to disable periodic execution */
 } mender_configure_config_t;
 
 /**
@@ -79,6 +79,14 @@ mender_err_t mender_configure_get(mender_keystore_t **configuration);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_configure_set(mender_keystore_t *configuration);
+
+/**
+ * @brief Function used to trigger execution of the configure work
+ * @note Calling this function is optional when the periodic execution of the work is configured
+ * @note It only permits to execute the work as soon as possible to synchronize configuration
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_configure_execute(void);
 
 /**
  * @brief Release mender configure add-on

--- a/include/mender-inventory.h
+++ b/include/mender-inventory.h
@@ -40,7 +40,7 @@ extern "C" {
  * @brief Mender inventory configuration
  */
 typedef struct {
-    uint32_t refresh_interval; /**< Inventory refresh interval, default is 28800 seconds */
+    int32_t refresh_interval; /**< Inventory refresh interval, default is 28800 seconds, -1 permits to disable periodic execution */
 } mender_inventory_config_t;
 
 /**
@@ -62,6 +62,14 @@ mender_err_t mender_inventory_activate(void);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_inventory_set(mender_keystore_t *inventory);
+
+/**
+ * @brief Function used to trigger execution of the inventory work
+ * @note Calling this function is optional when the periodic execution of the work is configured
+ * @note It only permits to execute the work as soon as possible to synchronize inventory
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_inventory_execute(void);
 
 /**
  * @brief Release mender inventory add-on

--- a/include/mender-rtos.h
+++ b/include/mender-rtos.h
@@ -39,8 +39,8 @@ extern "C" {
  */
 typedef struct {
     mender_err_t (*function)(void); /**< Work function */
-    uint32_t period;                /**< Work period (seconds), null value permits to disable periodic execution */
-    char *   name;                  /**< Work name */
+    int32_t period;                 /**< Work period (seconds), negative or null value permits to disable periodic execution */
+    char *  name;                   /**< Work name */
 } mender_rtos_work_params_t;
 
 /**

--- a/include/mender-rtos.h
+++ b/include/mender-rtos.h
@@ -73,6 +73,13 @@ mender_err_t mender_rtos_work_activate(void *handle);
 mender_err_t mender_rtos_work_set_period(void *handle, uint32_t period);
 
 /**
+ * @brief Function used to trigger execution of the work
+ * @param handle Work handle
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_rtos_work_execute(void *handle);
+
+/**
  * @brief Function used to deactivate a work
  * @param handle Work handle
  * @return MENDER_OK if the function succeeds, error code otherwise

--- a/include/mender-rtos.h
+++ b/include/mender-rtos.h
@@ -39,7 +39,7 @@ extern "C" {
  */
 typedef struct {
     mender_err_t (*function)(void); /**< Work function */
-    uint32_t period;                /**< Work period (seconds) */
+    uint32_t period;                /**< Work period (seconds), null value permits to disable periodic execution */
     char *   name;                  /**< Work name */
 } mender_rtos_work_params_t;
 

--- a/include/mender-troubleshoot.h
+++ b/include/mender-troubleshoot.h
@@ -40,7 +40,7 @@ extern "C" {
  * @brief Mender troubleshoot configuration
  */
 typedef struct {
-    uint32_t healthcheck_interval; /**< Troubleshoot healthcheck interval, default is 30 seconds */
+    int32_t healthcheck_interval; /**< Troubleshoot healthcheck interval, default is 30 seconds, -1 permits to disable periodic execution */
 } mender_troubleshoot_config_t;
 
 /**

--- a/platform/rtos/freertos/src/mender-rtos.c
+++ b/platform/rtos/freertos/src/mender-rtos.c
@@ -230,6 +230,20 @@ mender_rtos_work_set_period(void *handle, uint32_t period) {
 }
 
 mender_err_t
+mender_rtos_work_execute(void *handle) {
+
+    assert(NULL != handle);
+
+    /* Get work context */
+    mender_rtos_work_context_t *work_context = (mender_rtos_work_context_t *)handle;
+
+    /* Execute the work now */
+    mender_rtos_timer_callback(work_context->timer_handle);
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_rtos_work_deactivate(void *handle) {
 
     assert(NULL != handle);

--- a/platform/rtos/posix/src/mender-rtos.c
+++ b/platform/rtos/posix/src/mender-rtos.c
@@ -255,6 +255,22 @@ mender_rtos_work_set_period(void *handle, uint32_t period) {
 }
 
 mender_err_t
+mender_rtos_work_execute(void *handle) {
+
+    assert(NULL != handle);
+
+    /* Get work context */
+    mender_rtos_work_context_t *work_context = (mender_rtos_work_context_t *)handle;
+
+    /* Execute the work now */
+    union sigval timer_data;
+    timer_data.sival_ptr = (void *)work_context;
+    mender_rtos_timer_callback(timer_data);
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_rtos_work_deactivate(void *handle) {
 
     assert(NULL != handle);

--- a/platform/rtos/zephyr/src/mender-rtos.c
+++ b/platform/rtos/zephyr/src/mender-rtos.c
@@ -167,6 +167,20 @@ mender_rtos_work_activate(void *handle) {
 }
 
 mender_err_t
+mender_rtos_work_execute(void *handle) {
+
+    assert(NULL != handle);
+
+    /* Get work context */
+    mender_rtos_work_context_t *work_context = (mender_rtos_work_context_t *)handle;
+
+    /* Execute the work now */
+    mender_rtos_timer_callback(&work_context->timer_handle);
+
+    return MENDER_OK;
+}
+
+mender_err_t
 mender_rtos_work_set_period(void *handle, uint32_t period) {
 
     assert(NULL != handle);

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -69,6 +69,7 @@ if MENDER_MCU_CLIENT
             default 600
             help
                 Interval used to periodically try to authenticate to the Mender server until it succeeds.
+                Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
         config MENDER_CLIENT_UPDATE_POLL_INTERVAL
             int "Mender client Update poll interval (seconds)"
@@ -76,6 +77,7 @@ if MENDER_MCU_CLIENT
             default 1800
             help
                 Interval used to periodically check for new deployments on the Mender server.
+                Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
         module = MENDER
         module-str = Log Level for mender
@@ -108,6 +110,7 @@ if MENDER_MCU_CLIENT
                     default 28800
                     help
                         Interval used to periodically refresh configuration to/from the Mender server.
+                        Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
             endif
 
@@ -130,6 +133,7 @@ if MENDER_MCU_CLIENT
                     default 28800
                     help
                         Interval used to periodically send inventory to the Mender server.
+                        Setting this value to 0 permits to disable the periodic execution and relies on the application to do it.
 
             endif
 
@@ -148,7 +152,7 @@ if MENDER_MCU_CLIENT
 
                 config MENDER_CLIENT_TROUBLESHOOT_HEALTHCHECK_INTERVAL
                     int "Mender client Troubleshoot healthcheck interval (seconds)"
-                    range 0 60
+                    range 10 60
                     default 30
                     help
                         Interval used to periodically perform healthcheck with the Mender server.


### PR DESCRIPTION
The purpose of this Pull Request is to add APIs allowing the application to trigger works (authentication/update/inventory/configure).
Additionally, it is possible to disable the periodic execution of works by configuration, so both feature together permit to handle triggering of the execution of the mender client from the application.

Works are still executed from the mender work queue thread inside the rtos module to ensure priorities, stack size etc that are guaranteed by the rtos module scheduler.

The troubleshooting work cannot be stopped and triggered from the applications. There is no interest for that because it is a pure internal work to perform keep alive with the mender server.

This Pull Request replaces https://github.com/joelguittet/mender-mcu-client/pull/19 and offers a solution to https://github.com/joelguittet/mender-mcu-client/issues/17.