### PR TITLE
platform: keep authentication keys inside the tls module

### DIFF
--- a/include/mender-api.h
+++ b/include/mender-api.h
@@ -54,13 +54,9 @@ mender_err_t mender_api_init(mender_api_config_t *config);
 
 /**
  * @brief Perform authentication of the device, retrieve token from mender-server used for the next requests
- * @param private_key Client private key used for authentication
- * @param private_key_length Private key length
- * @param public_key Client public key used for authentication
- * @param public_key_length Public key length
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_api_perform_authentication(unsigned char *private_key, size_t private_key_length, unsigned char *public_key, size_t public_key_length);
+mender_err_t mender_api_perform_authentication(void);
 
 /**
  * @brief Check for deployments for the device from the mender-server

--- a/include/mender-tls.h
+++ b/include/mender-tls.h
@@ -41,40 +41,27 @@ extern "C" {
 mender_err_t mender_tls_init(void);
 
 /**
- * @brief Generate authentication keys
- * @param private_key Private key generated
- * @param private_key_length Private key lenght
- * @param public_key Public key generated
- * @param public_key_length Public key lenght
+ * @brief Initialize mender TLS authentication keys
+ * @param recommissioning perform recommisioning (if supported by the platform)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_tls_generate_authentication_keys(unsigned char **private_key,
-                                                     size_t *        private_key_length,
-                                                     unsigned char **public_key,
-                                                     size_t *        public_key_length);
+mender_err_t mender_tls_init_authentication_keys(bool recommissioning);
 
 /**
- * @brief Write a buffer of PEM information from a DER encoded buffer
- * @note This function is derived from mbedtls_pem_write_buffer with const header and footer, and line feed is "\\n"
- * @param der_data The DER data to encode
- * @param der_len The length of the DER data
- * @param buf The buffer to write to
- * @param buf_len The length of the output buffer
- * @param olen The address at which to store the total length written or required output buffer length is not enough
+ * @brief Get public key (PEM format suitable to be integrated in mender authentication request)
+ * @param public_key Public key, NULL if an error occured
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_tls_pem_write_buffer(const unsigned char *der_data, size_t der_len, char *buf, size_t buf_len, size_t *olen);
+mender_err_t mender_tls_get_public_key_pem(char **public_key);
 
 /**
  * @brief Sign payload
- * @param private_key Private key
- * @param private_key_length Private key length
  * @param payload Payload to sign
  * @param signature Signature of the payload
  * @param signature_length Length of the signature buffer, updated to the length of the signature
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_tls_sign_payload(unsigned char *private_key, size_t private_key_length, char *payload, char **signature, size_t *signature_length);
+mender_err_t mender_tls_sign_payload(char *payload, char **signature, size_t *signature_length);
 
 /**
  * @brief Release mender TLS

--- a/platform/tls/mbedtls/src/mender-tls.c
+++ b/platform/tls/mbedtls/src/mender-tls.c
@@ -36,6 +36,7 @@
 #include <mbedtls/rsa.h>
 #include <mbedtls/x509.h>
 #include "mender-log.h"
+#include "mender-storage.h"
 #include "mender-tls.h"
 
 /**
@@ -49,6 +50,39 @@
  */
 #define MENDER_TLS_SIGNATURE_LENGTH (512)
 
+/**
+ * @brief Authentication keys
+ */
+static unsigned char *mender_tls_private_key        = NULL;
+static size_t         mender_tls_private_key_length = 0;
+static unsigned char *mender_tls_public_key         = NULL;
+static size_t         mender_tls_public_key_length  = 0;
+
+/**
+ * @brief Generate authentication keys
+ * @param private_key Private key generated
+ * @param private_key_length Private key lenght
+ * @param public_key Public key generated
+ * @param public_key_length Public key lenght
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+static mender_err_t mender_tls_generate_authentication_keys(unsigned char **private_key,
+                                                            size_t *        private_key_length,
+                                                            unsigned char **public_key,
+                                                            size_t *        public_key_length);
+
+/**
+ * @brief Write a buffer of PEM information from a DER encoded buffer
+ * @note This function is derived from mbedtls_pem_write_buffer with const header and footer, and line feed is "\\n"
+ * @param der_data The DER data to encode
+ * @param der_len The length of the DER data
+ * @param buf The buffer to write to
+ * @param buf_len The length of the output buffer
+ * @param olen The address at which to store the total length written or required output buffer length is not enough
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+static mender_err_t mender_tls_pem_write_buffer(const unsigned char *der_data, size_t der_len, char *buf, size_t buf_len, size_t *olen);
+
 mender_err_t
 mender_tls_init(void) {
 
@@ -57,6 +91,252 @@ mender_tls_init(void) {
 }
 
 mender_err_t
+mender_tls_init_authentication_keys(bool recommissioning) {
+
+    mender_err_t ret;
+
+    /* Release memory */
+    if (NULL != mender_tls_private_key) {
+        free(mender_tls_private_key);
+        mender_tls_private_key = NULL;
+    }
+    mender_tls_private_key_length = 0;
+    if (NULL != mender_tls_public_key) {
+        free(mender_tls_public_key);
+        mender_tls_public_key = NULL;
+    }
+    mender_tls_public_key_length = 0;
+
+    /* Check if recommissioning is forced */
+    if (true == recommissioning) {
+
+        /* Erase authentication keys */
+        mender_log_info("Delete authentication keys...");
+        if (MENDER_OK != mender_storage_delete_authentication_keys()) {
+            mender_log_warning("Unable to delete authentication keys");
+        }
+    }
+
+    /* Retrieve or generate authentication keys if not allready done */
+    if (MENDER_OK
+        != (ret = mender_storage_get_authentication_keys(
+                &mender_tls_private_key, &mender_tls_private_key_length, &mender_tls_public_key, &mender_tls_public_key_length))) {
+
+        /* Generate authentication keys */
+        mender_log_info("Generating authentication keys...");
+        if (MENDER_OK
+            != (ret = mender_tls_generate_authentication_keys(
+                    &mender_tls_private_key, &mender_tls_private_key_length, &mender_tls_public_key, &mender_tls_public_key_length))) {
+            mender_log_error("Unable to generate authentication keys");
+            return ret;
+        }
+
+        /* Record keys */
+        if (MENDER_OK
+            != (ret = mender_storage_set_authentication_keys(
+                    mender_tls_private_key, mender_tls_private_key_length, mender_tls_public_key, mender_tls_public_key_length))) {
+            mender_log_error("Unable to record authentication keys");
+            return ret;
+        }
+    }
+
+    return ret;
+}
+
+mender_err_t
+mender_tls_get_public_key_pem(char **public_key) {
+
+    assert(NULL != public_key);
+    mender_err_t ret;
+
+    /* Compute size of the public key */
+    size_t olen = 0;
+    mender_tls_pem_write_buffer(mender_tls_public_key, mender_tls_public_key_length, NULL, 0, &olen);
+    if (0 == olen) {
+        mender_log_error("Unable to compute public key size");
+        return MENDER_FAIL;
+    }
+    if (NULL == (*public_key = (char *)malloc(olen))) {
+        mender_log_error("Unable to allocate memory");
+        return MENDER_FAIL;
+    }
+
+    /* Convert public key from DER to PEM format */
+    if (MENDER_OK != (ret = mender_tls_pem_write_buffer(mender_tls_public_key, mender_tls_public_key_length, *public_key, olen, &olen))) {
+        mender_log_error("Unable to convert public key");
+        return ret;
+    }
+
+    return MENDER_OK;
+}
+
+mender_err_t
+mender_tls_sign_payload(char *payload, char **signature, size_t *signature_length) {
+
+    assert(NULL != payload);
+    assert(NULL != signature);
+    assert(NULL != signature_length);
+    int                       ret;
+    mbedtls_pk_context *      pk_context = NULL;
+    mbedtls_ctr_drbg_context *ctr_drbg   = NULL;
+    mbedtls_entropy_context * entropy    = NULL;
+    unsigned char *           sig        = NULL;
+    size_t                    sig_length;
+    char *                    tmp;
+#ifdef MBEDTLS_ERROR_C
+    char err[128];
+#endif /* MBEDTLS_ERROR_C */
+
+    /* Initialize mbedtls */
+    if (NULL == (pk_context = (mbedtls_pk_context *)malloc(sizeof(mbedtls_pk_context)))) {
+        mender_log_error("Unable to allocate memory");
+        ret = -1;
+        goto END;
+    }
+    mbedtls_pk_init(pk_context);
+    if (NULL == (ctr_drbg = (mbedtls_ctr_drbg_context *)malloc(sizeof(mbedtls_ctr_drbg_context)))) {
+        mender_log_error("Unable to allocate memory");
+        ret = -1;
+        goto END;
+    }
+    mbedtls_ctr_drbg_init(ctr_drbg);
+    if (NULL == (entropy = (mbedtls_entropy_context *)malloc(sizeof(mbedtls_entropy_context)))) {
+        mender_log_error("Unable to allocate memory");
+        ret = -1;
+        goto END;
+    }
+    mbedtls_entropy_init(entropy);
+
+    /* Setup CRT DRBG */
+    if (0 != (ret = mbedtls_ctr_drbg_seed(ctr_drbg, mbedtls_entropy_func, entropy, (const unsigned char *)"mender", strlen("mender")))) {
+#ifdef MBEDTLS_ERROR_C
+        mbedtls_strerror(ret, err, sizeof(err));
+        mender_log_error("Unable to initialize ctr drbg (-0x%04x: %s)", -ret, err);
+#else
+        mender_log_error("Unable to initialize ctr drbg (-0x%04x)", -ret);
+#endif /* MBEDTLS_ERROR_C */
+        goto END;
+    }
+
+    /* Parse private key (IMPORTANT NOTE: length must include the ending \0 character) */
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+    if (0 != (ret = mbedtls_pk_parse_key(pk_context, mender_tls_private_key, mender_tls_private_key_length, NULL, 0, mbedtls_ctr_drbg_random, ctr_drbg))) {
+#else
+    if (0 != (ret = mbedtls_pk_parse_key(pk_context, mender_tls_private_key, mender_tls_private_key_length, NULL, 0))) {
+#endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
+#ifdef MBEDTLS_ERROR_C
+        mbedtls_strerror(ret, err, sizeof(err));
+        mender_log_error("Unable to parse private key (-0x%04x: %s)", -ret, err);
+#else
+        mender_log_error("Unable to parse private key (-0x%04x)", -ret);
+#endif /* MBEDTLS_ERROR_C */
+        goto END;
+    }
+
+    /* Generate digest */
+    uint8_t digest[32];
+    if (0 != (ret = mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), (unsigned char *)payload, strlen(payload), digest))) {
+#ifdef MBEDTLS_ERROR_C
+        mbedtls_strerror(ret, err, sizeof(err));
+        mender_log_error("Unable to generate digest (-0x%04x: %s)", -ret, err);
+#else
+        mender_log_error("Unable to generate digest (-0x%04x)", -ret);
+#endif /* MBEDTLS_ERROR_C */
+        goto END;
+    }
+
+    /* Compute signature */
+    if (NULL == (sig = (unsigned char *)malloc(MENDER_TLS_SIGNATURE_LENGTH + 1))) {
+        mender_log_error("Unable to allocate memory");
+        ret = -1;
+        goto END;
+    }
+    sig_length = MENDER_TLS_SIGNATURE_LENGTH + 1;
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+    if (0 != (ret = mbedtls_pk_sign(pk_context, MBEDTLS_MD_SHA256, digest, sizeof(digest), sig, sig_length, &sig_length, mbedtls_ctr_drbg_random, ctr_drbg))) {
+#else
+    if (0 != (ret = mbedtls_pk_sign(pk_context, MBEDTLS_MD_SHA256, digest, sizeof(digest), sig, &sig_length, mbedtls_ctr_drbg_random, ctr_drbg))) {
+#endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
+#ifdef MBEDTLS_ERROR_C
+        mbedtls_strerror(ret, err, sizeof(err));
+        mender_log_error("Unable to compute signature (-0x%04x: %s)", -ret, err);
+#else
+        mender_log_error("Unable to compute signature (-0x%04x)", -ret);
+#endif /* MBEDTLS_ERROR_C */
+        goto END;
+    }
+
+    /* Encode signature to base64 */
+    if (NULL == (*signature = (char *)malloc(MENDER_TLS_SIGNATURE_LENGTH + 1))) {
+        mender_log_error("Unable to allocate memory");
+        ret = -1;
+        goto END;
+    }
+    *signature_length = MENDER_TLS_SIGNATURE_LENGTH + 1;
+    if (0 != (ret = mbedtls_base64_encode((unsigned char *)*signature, *signature_length, signature_length, sig, sig_length))) {
+#ifdef MBEDTLS_ERROR_C
+        mbedtls_strerror(ret, err, sizeof(err));
+        mender_log_error("Unable to encode signature (-0x%04x: %s)", -ret, err);
+#else
+        mender_log_error("Unable to encode signature (-0x%04x)", -ret);
+#endif /* MBEDTLS_ERROR_C */
+        free(*signature);
+        *signature = NULL;
+        goto END;
+    }
+    *signature_length = strlen(*signature);
+    if (NULL == (tmp = realloc(*signature, *signature_length + 1))) {
+        mender_log_error("Unable to allocate memory");
+        free(*signature);
+        *signature = NULL;
+        ret        = -1;
+        goto END;
+    }
+    *signature = tmp;
+
+END:
+
+    /* Release mbedtls */
+    if (NULL != entropy) {
+        mbedtls_entropy_free(entropy);
+        free(entropy);
+    }
+    if (NULL != ctr_drbg) {
+        mbedtls_ctr_drbg_free(ctr_drbg);
+        free(ctr_drbg);
+    }
+    if (NULL != pk_context) {
+        mbedtls_pk_free(pk_context);
+        free(pk_context);
+    }
+
+    /* Release memory */
+    if (NULL != sig) {
+        free(sig);
+    }
+
+    return (0 != ret) ? MENDER_FAIL : MENDER_OK;
+}
+
+mender_err_t
+mender_tls_exit(void) {
+
+    /* Release memory */
+    if (NULL != mender_tls_private_key) {
+        free(mender_tls_private_key);
+        mender_tls_private_key = NULL;
+    }
+    mender_tls_private_key_length = 0;
+    if (NULL != mender_tls_public_key) {
+        free(mender_tls_public_key);
+        mender_tls_public_key = NULL;
+    }
+    mender_tls_public_key_length = 0;
+
+    return MENDER_OK;
+}
+
+static mender_err_t
 mender_tls_generate_authentication_keys(unsigned char **private_key, size_t *private_key_length, unsigned char **public_key, size_t *public_key_length) {
 
     assert(NULL != private_key);
@@ -208,7 +488,7 @@ END:
     return (0 != ret) ? MENDER_FAIL : MENDER_OK;
 }
 
-mender_err_t
+static mender_err_t
 mender_tls_pem_write_buffer(const unsigned char *der_data, size_t der_len, char *buf, size_t buf_len, size_t *olen) {
 
 #define PEM_BEGIN_PUBLIC_KEY "-----BEGIN PUBLIC KEY-----"
@@ -233,6 +513,12 @@ mender_tls_pem_write_buffer(const unsigned char *der_data, size_t der_len, char 
     if (use_len + add_len > buf_len) {
         *olen = use_len + add_len;
         ret   = MENDER_FAIL;
+        goto END;
+    }
+
+    /* Check buffer */
+    if (NULL == p) {
+        ret = MENDER_FAIL;
         goto END;
     }
 
@@ -285,160 +571,4 @@ END:
     }
 
     return ret;
-}
-
-mender_err_t
-mender_tls_sign_payload(unsigned char *private_key, size_t private_key_length, char *payload, char **signature, size_t *signature_length) {
-
-    assert(NULL != private_key);
-    assert(NULL != payload);
-    assert(NULL != signature);
-    assert(NULL != signature_length);
-    int                       ret;
-    mbedtls_pk_context *      pk_context = NULL;
-    mbedtls_ctr_drbg_context *ctr_drbg   = NULL;
-    mbedtls_entropy_context * entropy    = NULL;
-    unsigned char *           sig        = NULL;
-    size_t                    sig_length;
-    char *                    tmp;
-#ifdef MBEDTLS_ERROR_C
-    char err[128];
-#endif /* MBEDTLS_ERROR_C */
-
-    /* Initialize mbedtls */
-    if (NULL == (pk_context = (mbedtls_pk_context *)malloc(sizeof(mbedtls_pk_context)))) {
-        mender_log_error("Unable to allocate memory");
-        ret = -1;
-        goto END;
-    }
-    mbedtls_pk_init(pk_context);
-    if (NULL == (ctr_drbg = (mbedtls_ctr_drbg_context *)malloc(sizeof(mbedtls_ctr_drbg_context)))) {
-        mender_log_error("Unable to allocate memory");
-        ret = -1;
-        goto END;
-    }
-    mbedtls_ctr_drbg_init(ctr_drbg);
-    if (NULL == (entropy = (mbedtls_entropy_context *)malloc(sizeof(mbedtls_entropy_context)))) {
-        mender_log_error("Unable to allocate memory");
-        ret = -1;
-        goto END;
-    }
-    mbedtls_entropy_init(entropy);
-
-    /* Setup CRT DRBG */
-    if (0 != (ret = mbedtls_ctr_drbg_seed(ctr_drbg, mbedtls_entropy_func, entropy, (const unsigned char *)"mender", strlen("mender")))) {
-#ifdef MBEDTLS_ERROR_C
-        mbedtls_strerror(ret, err, sizeof(err));
-        mender_log_error("Unable to initialize ctr drbg (-0x%04x: %s)", -ret, err);
-#else
-        mender_log_error("Unable to initialize ctr drbg (-0x%04x)", -ret);
-#endif /* MBEDTLS_ERROR_C */
-        goto END;
-    }
-
-    /* Parse private key (IMPORTANT NOTE: length must include the ending \0 character) */
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    if (0 != (ret = mbedtls_pk_parse_key(pk_context, private_key, private_key_length, NULL, 0, mbedtls_ctr_drbg_random, ctr_drbg))) {
-#else
-    if (0 != (ret = mbedtls_pk_parse_key(pk_context, private_key, private_key_length, NULL, 0))) {
-#endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
-#ifdef MBEDTLS_ERROR_C
-        mbedtls_strerror(ret, err, sizeof(err));
-        mender_log_error("Unable to parse private key (-0x%04x: %s)", -ret, err);
-#else
-        mender_log_error("Unable to parse private key (-0x%04x)", -ret);
-#endif /* MBEDTLS_ERROR_C */
-        goto END;
-    }
-
-    /* Generate digest */
-    uint8_t digest[32];
-    if (0 != (ret = mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), (unsigned char *)payload, strlen(payload), digest))) {
-#ifdef MBEDTLS_ERROR_C
-        mbedtls_strerror(ret, err, sizeof(err));
-        mender_log_error("Unable to generate digest (-0x%04x: %s)", -ret, err);
-#else
-        mender_log_error("Unable to generate digest (-0x%04x)", -ret);
-#endif /* MBEDTLS_ERROR_C */
-        goto END;
-    }
-
-    /* Compute signature */
-    if (NULL == (sig = (unsigned char *)malloc(MENDER_TLS_SIGNATURE_LENGTH + 1))) {
-        mender_log_error("Unable to allocate memory");
-        ret = -1;
-        goto END;
-    }
-    sig_length = MENDER_TLS_SIGNATURE_LENGTH + 1;
-#if MBEDTLS_VERSION_NUMBER >= 0x03000000
-    if (0 != (ret = mbedtls_pk_sign(pk_context, MBEDTLS_MD_SHA256, digest, sizeof(digest), sig, sig_length, &sig_length, mbedtls_ctr_drbg_random, ctr_drbg))) {
-#else
-    if (0 != (ret = mbedtls_pk_sign(pk_context, MBEDTLS_MD_SHA256, digest, sizeof(digest), sig, &sig_length, mbedtls_ctr_drbg_random, ctr_drbg))) {
-#endif /* MBEDTLS_VERSION_NUMBER >= 0x03000000 */
-#ifdef MBEDTLS_ERROR_C
-        mbedtls_strerror(ret, err, sizeof(err));
-        mender_log_error("Unable to compute signature (-0x%04x: %s)", -ret, err);
-#else
-        mender_log_error("Unable to compute signature (-0x%04x)", -ret);
-#endif /* MBEDTLS_ERROR_C */
-        goto END;
-    }
-
-    /* Encode signature to base64 */
-    if (NULL == (*signature = (char *)malloc(MENDER_TLS_SIGNATURE_LENGTH + 1))) {
-        mender_log_error("Unable to allocate memory");
-        ret = -1;
-        goto END;
-    }
-    *signature_length = MENDER_TLS_SIGNATURE_LENGTH + 1;
-    if (0 != (ret = mbedtls_base64_encode((unsigned char *)*signature, *signature_length, signature_length, sig, sig_length))) {
-#ifdef MBEDTLS_ERROR_C
-        mbedtls_strerror(ret, err, sizeof(err));
-        mender_log_error("Unable to encode signature (-0x%04x: %s)", -ret, err);
-#else
-        mender_log_error("Unable to encode signature (-0x%04x)", -ret);
-#endif /* MBEDTLS_ERROR_C */
-        free(*signature);
-        *signature = NULL;
-        goto END;
-    }
-    *signature_length = strlen(*signature);
-    if (NULL == (tmp = realloc(*signature, *signature_length + 1))) {
-        mender_log_error("Unable to allocate memory");
-        free(*signature);
-        *signature = NULL;
-        ret        = -1;
-        goto END;
-    }
-    *signature = tmp;
-
-END:
-
-    /* Release mbedtls */
-    if (NULL != entropy) {
-        mbedtls_entropy_free(entropy);
-        free(entropy);
-    }
-    if (NULL != ctr_drbg) {
-        mbedtls_ctr_drbg_free(ctr_drbg);
-        free(ctr_drbg);
-    }
-    if (NULL != pk_context) {
-        mbedtls_pk_free(pk_context);
-        free(pk_context);
-    }
-
-    /* Release memory */
-    if (NULL != sig) {
-        free(sig);
-    }
-
-    return (0 != ret) ? MENDER_FAIL : MENDER_OK;
-}
-
-mender_err_t
-mender_tls_exit(void) {
-
-    /* Nothing to do */
-    return MENDER_OK;
 }


### PR DESCRIPTION
The purpose of this Pull Request is to modify the API of the mender-tls module to keep authentication keys inside the module instead of managing this in the client and api levels.

This is to prepare new mender-tls options such as secure element integration.