### PR TITLE
client: return error in case the authentication is not done

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -425,7 +425,7 @@ REBOOT:
         mender_client_callbacks.restart();
     }
 
-    return MENDER_DONE;
+    return ret;
 }
 
 static mender_err_t


### PR DESCRIPTION
The purpose of this Pull Request is to handle authentication failure degraded case. It has been observed with a buggy artifact that was needed to rollback while authentication with the mender server fails due to invalid mender server URL.