### PR TITLE
Add support to update modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ Additionally, building the Device Troubleshoot add-on requires [msgpack-c](https
 
 The examples provide details to generate properly the artifact to be used. The most important is to create artifact with no compression at all, because the mender-mcu-client is not able to manage decompression of the artifact on the fly (it is flashed by blocks during the reception from the mender server).
 
-To create a new artifact first retrieve [mender-artifact](https://docs.mender.io/downloads#mender-artifact) tool. Then you should follow the template below to create the artifact:
+Artifact are created using [mender-artifact](https://docs.mender.io/downloads#mender-artifact) tool.
+
+### rootfs-image
+
+Follow the template below to create an artifact intended for firmware update:
 
 ```
 ./mender-artifact write rootfs-image --compression none --device-type <DEVICE-TYPE> --artifact-name <ARTIFACT-NAME> --output-path <ARTIFACT-FILE>.mender --file <BIN-FILE>
@@ -65,6 +69,21 @@ Where:
 * `ARTIFACT-NAME` is the artifact name to be used on mender, it should include the version number, for example `my-artifact-v1.0.0`.
 * `ARTIFACT-FILE` is the artifact output file to be uploaded on mender server.
 * `BIN-FILE` is the application binary file to be flashed on the MCU in the next OTA partition.
+
+### module-image
+
+Follow the template below to create an artifact intended for module update:
+
+```
+./mender-artifact write module-image --compression none --device-type <DEVICE-TYPE> --artifact-name <ARTIFACT-NAME> --type <MODULE-TYPE> --output-path <ARTIFACT-FILE>.mender --file <MODULE-FILE>
+```
+
+Where:
+* `DEVICE-TYPE` is the device type to be used on mender, for example `my-super-device`.
+* `ARTIFACT-NAME` is the artifact name to be used on mender, it should include the version number, for example `my-artifact-v1.0.0`.
+* `MODULE-TYPE` is the module type to be registered on the device to the mender client, for example `my-artifact`.
+* `ARTIFACT-FILE` is the artifact output file to be uploaded on mender server.
+* `MODULE-FILE` is the module file to be upgraded on the MCU. Multiple files are allowed repeating the option.
 
 
 ## API
@@ -143,7 +162,6 @@ It is possible to reduce even more the footprint of the mender-mcu-client librar
 
 The following features are currently in the pipeline. Please note that I haven't set dates in this road-map because I develop this in my free time, but you can contribute with Pull Requests:
 
-* Support update of [modules](https://docs.mender.io/artifact-creation/create-a-custom-update-module) to perform other kind of updates that could be specific to one project: files, images, etc.
 * Integration of other nice to have Mender features: Device Troubleshoot sending and receiving files, ...
 * Support new boards and prove it is cross-platform and that it is able to work on small MCU too: STM32F7, ATSAMD51...
 * Support other RTOS (particularly Azure RTOS) and bare metal platforms.

--- a/add-ons/src/mender-configure.c
+++ b/add-ons/src/mender-configure.c
@@ -26,6 +26,7 @@
  */
 
 #include "mender-api.h"
+#include "mender-client.h"
 #include "mender-configure.h"
 #include "mender-log.h"
 #include "mender-rtos.h"
@@ -67,10 +68,28 @@ static void *mender_configure_work_handle = NULL;
  */
 static mender_err_t mender_configure_work_function(void);
 
+/**
+ * @brief Callback function to be invoked to perform the treatment of the data from the artifact type "mender-configure"
+ * @param id ID of the deployment
+ * @param artifact name Artifact name
+ * @param type Type from header-info payloads
+ * @param meta_data Meta-data from header tarball
+ * @param filename Artifact filename
+ * @param size Artifact file size
+ * @param data Artifact data
+ * @param index Artifact data index
+ * @param length Artifact data length
+ * @return MENDER_OK if the function succeeds, error code if an error occured
+ */
+static mender_err_t mender_configure_download_artifact_callback(
+    char *id, char *artifact_name, char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length);
+
 mender_err_t
 mender_configure_init(mender_configure_config_t *config, mender_configure_callbacks_t *callbacks) {
 
     assert(NULL != config);
+    char *       device_config      = NULL;
+    cJSON *      json_device_config = NULL;
     mender_err_t ret;
 
     /* Save configuration */
@@ -86,28 +105,40 @@ mender_configure_init(mender_configure_config_t *config, mender_configure_callba
     /* Create configure mutex */
     if (MENDER_OK != (ret = mender_rtos_mutex_create(&mender_configure_mutex))) {
         mender_log_error("Unable to create configure mutex");
-        return ret;
+        goto END;
     }
 
 #ifdef CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE
 
     /* Initialize configuration from storage (if it is not empty) */
-    char *device_config = NULL;
     if (MENDER_OK != (ret = mender_storage_get_device_config(&device_config))) {
         if (MENDER_NOT_FOUND != ret) {
             mender_log_error("Unable to get device configuration");
-            return ret;
+            goto END;
         }
     }
 
     /* Set device configuration */
     if (NULL != device_config) {
-        if (MENDER_OK != (ret = mender_utils_keystore_from_string(&mender_configure_keystore, device_config))) {
+        if (NULL == (json_device_config = cJSON_Parse(device_config))) {
             mender_log_error("Unable to set device configuration");
-            free(device_config);
-            return ret;
+            ret = MENDER_FAIL;
+            goto END;
         }
-        free(device_config);
+        if (MENDER_OK != (ret = mender_utils_keystore_from_json(&mender_configure_keystore, cJSON_GetObjectItemCaseSensitive(json_device_config, "config")))) {
+            mender_log_error("Unable to set device configuration");
+            goto END;
+        }
+    }
+
+    /* Register mender-configure artifact type */
+    if (MENDER_OK
+        != (ret = mender_client_register_artifact_type("mender-configure",
+                                                       &mender_configure_download_artifact_callback,
+                                                       true,
+                                                       cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(json_device_config, "artifact_name"))))) {
+        mender_log_error("Unable to register 'mender-configure' artifact type");
+        goto END;
     }
 
 #endif /* CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE */
@@ -119,7 +150,17 @@ mender_configure_init(mender_configure_config_t *config, mender_configure_callba
     configure_work_params.name     = "mender_configure";
     if (MENDER_OK != (ret = mender_rtos_work_create(&configure_work_params, &mender_configure_work_handle))) {
         mender_log_error("Unable to create configure work");
-        return ret;
+        goto END;
+    }
+
+END:
+
+    /* Release memory */
+    if (NULL != device_config) {
+        free(device_config);
+    }
+    if (NULL != json_device_config) {
+        cJSON_Delete(json_device_config);
     }
 
     return ret;
@@ -168,6 +209,9 @@ END:
 mender_err_t
 mender_configure_set(mender_keystore_t *configuration) {
 
+    cJSON *      json_device_config = NULL;
+    cJSON *      json_config        = NULL;
+    char *       device_config      = NULL;
     mender_err_t ret;
 
     /* Take mutex used to protect access to the configuration key-store */
@@ -191,21 +235,42 @@ mender_configure_set(mender_keystore_t *configuration) {
 #ifdef CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE
 
     /* Save the device configuration */
-    char *device_config = NULL;
-    if (MENDER_OK != (ret = mender_utils_keystore_to_string(mender_configure_keystore, &device_config))) {
+    if (NULL == (json_device_config = cJSON_CreateObject())) {
+        mender_log_error("Unable to allocate memory");
+        ret = MENDER_FAIL;
+        goto END;
+    }
+    if (MENDER_OK != (ret = mender_utils_keystore_to_json(mender_configure_keystore, &json_config))) {
         mender_log_error("Unable to format configuration");
         goto END;
     }
-    if (NULL != device_config) {
-        if (MENDER_OK != (ret = mender_storage_set_device_config(device_config))) {
-            mender_log_error("Unable to record configuration");
-        }
-        free(device_config);
+    if (NULL == json_config) {
+        mender_log_error("Unable to format configuration");
+        ret = MENDER_FAIL;
+        goto END;
+    }
+    cJSON_AddItemToObject(json_device_config, "config", json_config);
+    if (NULL == (device_config = cJSON_PrintUnformatted(json_device_config))) {
+        mender_log_error("Unable to allocate memory");
+        ret = MENDER_FAIL;
+        goto END;
+    }
+    if (MENDER_OK != (ret = mender_storage_set_device_config(device_config))) {
+        mender_log_error("Unable to record configuration");
+        goto END;
     }
 
 #endif /* CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE */
 
 END:
+
+    /* Release memory */
+    if (NULL != json_device_config) {
+        cJSON_Delete(json_device_config);
+    }
+    if (NULL != device_config) {
+        free(device_config);
+    }
 
     /* Release mutex used to protect access to the configuration key-store */
     mender_rtos_mutex_give(mender_configure_mutex);
@@ -313,5 +378,65 @@ END:
 
     return ret;
 }
+
+#ifdef CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE
+
+static mender_err_t
+mender_configure_download_artifact_callback(
+    char *id, char *artifact_name, char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length) {
+
+    (void)id;
+    (void)type;
+    (void)filename;
+    (void)size;
+    (void)data;
+    (void)index;
+    (void)length;
+    cJSON *      json_device_config = NULL;
+    char *       device_config      = NULL;
+    mender_err_t ret                = MENDER_OK;
+
+    /* Check meta-data */
+    if (NULL != meta_data) {
+
+        /* Save the device configuration */
+        if (NULL == (json_device_config = cJSON_CreateObject())) {
+            mender_log_error("Unable to allocate memory");
+            ret = MENDER_FAIL;
+            goto END;
+        }
+        cJSON_AddStringToObject(json_device_config, "artifact_name", artifact_name);
+        cJSON_AddItemToObject(json_device_config, "config", meta_data);
+        if (NULL == (device_config = cJSON_PrintUnformatted(json_device_config))) {
+            mender_log_error("Unable to allocate memory");
+            ret = MENDER_FAIL;
+            goto END;
+        }
+        if (MENDER_OK != (ret = mender_storage_set_device_config(device_config))) {
+            mender_log_error("Unable to record configuration");
+            goto END;
+        }
+
+    } else {
+
+        /* Delete the configuration */
+        if (MENDER_OK != (ret = mender_storage_delete_device_config())) {
+            mender_log_error("Unable to delete configuration");
+        }
+    }
+
+END:
+
+    /* Release memory */
+    if (NULL != json_device_config) {
+        cJSON_Delete(json_device_config);
+    }
+    if (NULL != device_config) {
+        free(device_config);
+    }
+    return ret;
+}
+
+#endif /* CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE */
 
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE */

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -55,14 +55,7 @@ typedef struct {
     mender_err_t (*authentication_success)(void);                          /**< Invoked when authentication with the mender server succeeded */
     mender_err_t (*authentication_failure)(void);                          /**< Invoked when authentication with the mender server failed */
     mender_err_t (*deployment_status)(mender_deployment_status_t, char *); /**< Invoked on transition changes to inform of the new deployment status */
-    struct {
-        mender_err_t (*open)(char *, size_t, void **);         /**< Invoked to open flash device when the deployment begins */
-        mender_err_t (*write)(void *, void *, size_t, size_t); /**< Invoked to write data received from the mender server */
-        mender_err_t (*close)(void *);                         /**< Invoked to indicate the end of the artifact */
-        mender_err_t (*set_pending_image)(void *);             /**< Invoked to set the new boot partition to be used on the next restart */
-        mender_err_t (*abort_deployment)(void *);              /**< Invoked to abort current deployment */
-    } flash;
-    mender_err_t (*restart)(void); /**< Invoked to restart the device */
+    mender_err_t (*restart)(void);                                         /**< Invoked to restart the device */
 } mender_client_callbacks_t;
 
 /**
@@ -78,6 +71,19 @@ char *mender_client_version(void);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_client_init(mender_client_config_t *config, mender_client_callbacks_t *callbacks);
+
+/**
+ * @brief Register artifact type
+ * @param type Artifact type
+ * @param callback Artifact type callback
+ * @param needs_restart Flag to indicate if the artifact type requires the device to restart after downloading
+ * @param artifact_name Artifact name (optional, NULL otherwise), set to validate module update after restarting
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_register_artifact_type(char *type,
+                                                  mender_err_t (*callback)(char *, char *, char *, cJSON *, char *, size_t, void *, size_t, size_t),
+                                                  bool  needs_restart,
+                                                  char *artifact_name);
 
 /**
  * @brief Function used to trigger execution of the authentication and update work

--- a/include/mender-storage.h
+++ b/include/mender-storage.h
@@ -70,26 +70,24 @@ mender_err_t mender_storage_get_authentication_keys(unsigned char **private_key,
 mender_err_t mender_storage_delete_authentication_keys(void);
 
 /**
- * @brief Set deployment
- * @param id Deployment ID to store
- * @param artifact_name Deployment artifact name to store
+ * @brief Set deployment data
+ * @param deployment_data Deployment data to store
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_storage_set_deployment(char *id, char *artifact_name);
+mender_err_t mender_storage_set_deployment_data(char *deployment_data);
 
 /**
- * @brief Get deployment
- * @param id Deployment ID from storage, NULL if not found
- * @param artifact_name Deployment artifact name from storage, NULL if not found
+ * @brief Get deployment data
+ * @param deployment_data Deployment data from storage, NULL if not found
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_storage_get_deployment(char **id, char **artifact_name);
+mender_err_t mender_storage_get_deployment_data(char **deployment_data);
 
 /**
- * @brief Delete deployment
+ * @brief Delete deployment data
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_storage_delete_deployment(void);
+mender_err_t mender_storage_delete_deployment_data(void);
 
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE
 #ifdef CONFIG_MENDER_CLIENT_CONFIGURE_STORAGE

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -142,18 +142,18 @@ mender_err_t mender_utils_keystore_copy(mender_keystore_t **dst_keystore, mender
 /**
  * @brief Function used to set key-store from JSON string
  * @param keystore Key-store
- * @param data JSON string
+ * @param object JSON object
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_utils_keystore_from_string(mender_keystore_t **keystore, char *data);
+mender_err_t mender_utils_keystore_from_json(mender_keystore_t **keystore, cJSON *object);
 
 /**
- * @brief Function used to format key-store to JSON string
+ * @brief Function used to format key-store to JSON object
  * @param keystore Key-store
- * @param data JSON string
+ * @param object JSON object
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_utils_keystore_to_string(mender_keystore_t *keystore, char **data);
+mender_err_t mender_utils_keystore_to_json(mender_keystore_t *keystore, cJSON **object);
 
 /**
  * @brief Function used to set key-store item name and value

--- a/platform/storage/esp-idf/nvs/src/mender-storage.c
+++ b/platform/storage/esp-idf/nvs/src/mender-storage.c
@@ -32,11 +32,10 @@
 /**
  * @brief NVS keys
  */
-#define MENDER_STORAGE_NVS_PRIVATE_KEY              "key.der"
-#define MENDER_STORAGE_NVS_PUBLIC_KEY               "pubkey.der"
-#define MENDER_STORAGE_NVS_DEPLOYMENT_ID            "id"
-#define MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME "artifact_name"
-#define MENDER_STORAGE_NVS_DEVICE_CONFIG            "config.json"
+#define MENDER_STORAGE_NVS_PRIVATE_KEY     "key.der"
+#define MENDER_STORAGE_NVS_PUBLIC_KEY      "pubkey.der"
+#define MENDER_STORAGE_NVS_DEPLOYMENT_DATA "deployment_data"
+#define MENDER_STORAGE_NVS_DEVICE_CONFIG   "config.json"
 
 /**
  * @brief NVS storage handle
@@ -135,19 +134,17 @@ mender_storage_delete_authentication_keys(void) {
 }
 
 mender_err_t
-mender_storage_set_deployment(char *id, char *artifact_name) {
+mender_storage_set_deployment_data(char *deployment_data) {
 
-    assert(NULL != id);
-    assert(NULL != artifact_name);
+    assert(NULL != deployment_data);
 
-    /* Write ID and artifact name */
-    if ((ESP_OK != nvs_set_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID, id))
-        || (ESP_OK != nvs_set_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME, artifact_name))) {
-        mender_log_error("Unable to write deployment ID or artifact name");
+    /* Write deployment data */
+    if (ESP_OK != nvs_set_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA, deployment_data)) {
+        mender_log_error("Unable to write deployment data");
         return MENDER_FAIL;
     }
     if (ESP_OK != nvs_commit(mender_storage_nvs_handle)) {
-        mender_log_error("Unable to write deployment ID or artifact name");
+        mender_log_error("Unable to write deployment data");
         return MENDER_FAIL;
     }
 
@@ -155,41 +152,29 @@ mender_storage_set_deployment(char *id, char *artifact_name) {
 }
 
 mender_err_t
-mender_storage_get_deployment(char **id, char **artifact_name) {
+mender_storage_get_deployment_data(char **deployment_data) {
 
-    assert(NULL != id);
-    assert(NULL != artifact_name);
-    size_t id_length            = 0;
-    size_t artifact_name_length = 0;
+    assert(NULL != deployment_data);
+    size_t deployment_data_length = 0;
 
-    /* Retrieve length of the ID and artifact name */
-    nvs_get_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID, NULL, &id_length);
-    nvs_get_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME, NULL, &artifact_name_length);
-    if ((0 == id_length) || (0 == artifact_name_length)) {
-        mender_log_info("Deployment ID or artifact name not available");
+    /* Retrieve length of the deployment data */
+    nvs_get_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA, NULL, &deployment_data_length);
+    if (0 == deployment_data_length) {
+        mender_log_info("Deployment data not available");
         return MENDER_NOT_FOUND;
     }
 
-    /* Allocate memory to copy deployment ID and artifact name */
-    if (NULL == (*id = (char *)malloc(id_length + 1))) {
+    /* Allocate memory to copy deployment data */
+    if (NULL == (*deployment_data = (char *)malloc(deployment_data_length + 1))) {
         mender_log_error("Unable to allocate memory");
-        return MENDER_FAIL;
-    }
-    if (NULL == (*artifact_name = (char *)malloc(artifact_name_length + 1))) {
-        mender_log_error("Unable to allocate memory");
-        free(*id);
-        *id = NULL;
         return MENDER_FAIL;
     }
 
-    /* Read ID and artifact name */
-    if ((ESP_OK != nvs_get_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID, *id, &id_length))
-        || (ESP_OK != nvs_get_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME, *artifact_name, &artifact_name_length))) {
-        mender_log_error("Unable to read deployment ID or artifact name");
-        free(*id);
-        *id = NULL;
-        free(*artifact_name);
-        *artifact_name = NULL;
+    /* Read deployment data */
+    if (ESP_OK != nvs_get_str(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA, *deployment_data, &deployment_data_length)) {
+        mender_log_error("Unable to read deployment data");
+        free(*deployment_data);
+        *deployment_data = NULL;
         return MENDER_FAIL;
     }
 
@@ -197,12 +182,11 @@ mender_storage_get_deployment(char **id, char **artifact_name) {
 }
 
 mender_err_t
-mender_storage_delete_deployment(void) {
+mender_storage_delete_deployment_data(void) {
 
-    /* Delete deployment ID and artifact name */
-    if ((ESP_OK != nvs_erase_key(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID))
-        || (ESP_OK != nvs_erase_key(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME))) {
-        mender_log_error("Unable to delete deployment ID or artifact name");
+    /* Delete deployment data */
+    if (ESP_OK != nvs_erase_key(mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA)) {
+        mender_log_error("Unable to delete deployment data");
         return MENDER_FAIL;
     }
 

--- a/platform/storage/generic/weak/src/mender-storage.c
+++ b/platform/storage/generic/weak/src/mender-storage.c
@@ -67,27 +67,25 @@ mender_storage_delete_authentication_keys(void) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_storage_set_deployment(char *id, char *artifact_name) {
+mender_storage_set_deployment_data(char *deployment_data) {
 
-    (void)id;
-    (void)artifact_name;
-
-    /* Nothing to do */
-    return MENDER_NOT_IMPLEMENTED;
-}
-
-__attribute__((weak)) mender_err_t
-mender_storage_get_deployment(char **id, char **artifact_name) {
-
-    (void)id;
-    (void)artifact_name;
+    (void)deployment_data;
 
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;
 }
 
 __attribute__((weak)) mender_err_t
-mender_storage_delete_deployment(void) {
+mender_storage_get_deployment_data(char **deployment_data) {
+
+    (void)deployment_data;
+
+    /* Nothing to do */
+    return MENDER_NOT_IMPLEMENTED;
+}
+
+__attribute__((weak)) mender_err_t
+mender_storage_delete_deployment_data(void) {
 
     /* Nothing to do */
     return MENDER_NOT_IMPLEMENTED;

--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -41,11 +41,10 @@
 /**
  * @brief NVS keys
  */
-#define MENDER_STORAGE_NVS_PRIVATE_KEY              1
-#define MENDER_STORAGE_NVS_PUBLIC_KEY               2
-#define MENDER_STORAGE_NVS_DEPLOYMENT_ID            3
-#define MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME 4
-#define MENDER_STORAGE_NVS_DEVICE_CONFIG            5
+#define MENDER_STORAGE_NVS_PRIVATE_KEY     1
+#define MENDER_STORAGE_NVS_PUBLIC_KEY      2
+#define MENDER_STORAGE_NVS_DEPLOYMENT_DATA 3
+#define MENDER_STORAGE_NVS_DEVICE_CONFIG   4
 
 /**
  * @brief NVS storage handle
@@ -158,15 +157,13 @@ mender_storage_delete_authentication_keys(void) {
 }
 
 mender_err_t
-mender_storage_set_deployment(char *id, char *artifact_name) {
+mender_storage_set_deployment_data(char *deployment_data) {
 
-    assert(NULL != id);
-    assert(NULL != artifact_name);
+    assert(NULL != deployment_data);
 
-    /* Write ID and artifact name */
-    if ((nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID, id, strlen(id) + 1) < 0)
-        || (nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME, artifact_name, strlen(artifact_name) + 1) < 0)) {
-        mender_log_error("Unable to write deployment ID or artifact name");
+    /* Write deployment data */
+    if (nvs_write(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA, deployment_data, strlen(deployment_data) + 1) < 0) {
+        mender_log_error("Unable to write deployment data");
         return MENDER_FAIL;
     }
 
@@ -174,46 +171,30 @@ mender_storage_set_deployment(char *id, char *artifact_name) {
 }
 
 mender_err_t
-mender_storage_get_deployment(char **id, char **artifact_name) {
+mender_storage_get_deployment_data(char **deployment_data) {
 
-    assert(NULL != id);
-    assert(NULL != artifact_name);
-    size_t  id_length            = 0;
-    size_t  artifact_name_length = 0;
+    assert(NULL != deployment_data);
+    size_t  deployment_data_length = 0;
     ssize_t ret;
 
-    /* Retrieve length of the ID and artifact name */
-    if ((ret = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID, NULL, 0)) <= 0) {
-        mender_log_info("Deployment ID not available");
+    /* Retrieve length of the deployment data */
+    if ((ret = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA, NULL, 0)) <= 0) {
+        mender_log_info("Deployment data not available");
         return MENDER_NOT_FOUND;
     }
-    id_length = (size_t)ret;
-    if ((ret = nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME, NULL, 0)) <= 0) {
-        mender_log_info("Artifact name not available");
-        return MENDER_NOT_FOUND;
-    }
-    artifact_name_length = (size_t)ret;
+    deployment_data_length = (size_t)ret;
 
-    /* Allocate memory to copy ID and artifact name */
-    if (NULL == (*id = (char *)malloc(id_length))) {
+    /* Allocate memory to copy deployment data */
+    if (NULL == (*deployment_data = (char *)malloc(deployment_data_length))) {
         mender_log_error("Unable to allocate memory");
         return MENDER_FAIL;
     }
-    if (NULL == (*artifact_name = (char *)malloc(artifact_name_length))) {
-        mender_log_error("Unable to allocate memory");
-        free(*id);
-        *id = NULL;
-        return MENDER_FAIL;
-    }
 
-    /* Read ID and artifact name */
-    if ((nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID, *id, id_length) < 0)
-        || (nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME, *artifact_name, artifact_name_length) < 0)) {
-        mender_log_error("Unable to read deployment ID or artifact name");
-        free(*id);
-        *id = NULL;
-        free(*artifact_name);
-        *artifact_name = NULL;
+    /* Read deployment data */
+    if (nvs_read(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA, *deployment_data, deployment_data_length) < 0) {
+        mender_log_error("Unable to read deployment data");
+        free(*deployment_data);
+        *deployment_data = NULL;
         return MENDER_FAIL;
     }
 
@@ -221,12 +202,11 @@ mender_storage_get_deployment(char **id, char **artifact_name) {
 }
 
 mender_err_t
-mender_storage_delete_deployment(void) {
+mender_storage_delete_deployment_data(void) {
 
-    /* Delete ID and artifact name */
-    if ((0 != nvs_delete(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ID))
-        || (0 != nvs_delete(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_ARTIFACT_NAME))) {
-        mender_log_error("Unable to delete deployment ID or artifact name");
+    /* Delete deployment data */
+    if (0 != nvs_delete(&mender_storage_nvs_handle, MENDER_STORAGE_NVS_DEPLOYMENT_DATA)) {
+        mender_log_error("Unable to delete deployment data");
         return MENDER_FAIL;
     }
 


### PR DESCRIPTION
The purpose of this Pull Request is to add support to update modules (#40)

No examples are available at the moment. To use modules, the module type should be registered to the mender client just after `mender_cleint_init` is called, as shown on the following skeleton:

```
/* Register module-readme artifact type */
if (MENDER_OK != mender_client_register_artifact_type("hello-world", &module_hello_world_cb, false, NULL)) {
    mender_log_error("Unable to register 'module-readme' artifact type");
    ret = EXIT_FAILURE;
    goto RELEASE;
}
```

The callback is used to retrieve module content when a deployment is in progress. Because this mechanism is generic, the mender client doesn't provide much more support and specific application implementation should be done depending of the module.

```
static mender_err_t
module_hello_world_cb(char *id, char *artifact_name, char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length) {
    //specific stuff depending of the module, upgrading local files or an external module for example
    return MENDER_OK; //Or MENDER_FAIL in case of error, to abord the download
}
```

Multiple modules types can be registered. Support of artifact name verification after reboot is also provided to report success/failure after installation (latest argument of the `mender_client_register_artifact_type` function).