### PR TITLE
platform: net: zephyr: remove usage of posix apis, prefer using zephyr native functions

### DIFF
--- a/platform/net/zephyr/src/mender-net.c
+++ b/platform/net/zephyr/src/mender-net.c
@@ -108,10 +108,10 @@ mender_net_connect(const char *host, const char *port, int *sock) {
     assert(NULL != host);
     assert(NULL != port);
     assert(NULL != sock);
-    int              result;
-    mender_err_t     ret = MENDER_OK;
-    struct addrinfo  hints;
-    struct addrinfo *addr = NULL;
+    int                    result;
+    mender_err_t           ret = MENDER_OK;
+    struct zsock_addrinfo  hints;
+    struct zsock_addrinfo *addr = NULL;
 
     /* Set hints */
     memset(&hints, 0, sizeof(hints));
@@ -124,7 +124,7 @@ mender_net_connect(const char *host, const char *port, int *sock) {
     hints.ai_protocol = IPPROTO_TCP;
 
     /* Perform DNS resolution of the host */
-    if (0 != (result = getaddrinfo(host, port, &hints, &addr))) {
+    if (0 != (result = zsock_getaddrinfo(host, port, &hints, &addr))) {
         mender_log_error("Unable to resolve host name '%s:%s', result = %d, errno = %d", host, port, result, errno);
         ret = MENDER_FAIL;
         goto END;
@@ -132,9 +132,9 @@ mender_net_connect(const char *host, const char *port, int *sock) {
 
     /* Create socket */
 #ifdef CONFIG_NET_SOCKETS_SOCKOPT_TLS
-    if ((result = socket(addr->ai_family, SOCK_STREAM, IPPROTO_TLS_1_2)) < 0) {
+    if ((result = zsock_socket(addr->ai_family, SOCK_STREAM, IPPROTO_TLS_1_2)) < 0) {
 #else
-    if ((result = socket(addr->ai_family, SOCK_STREAM, IPPROTO_TCP)) < 0) {
+    if ((result = zsock_socket(addr->ai_family, SOCK_STREAM, IPPROTO_TCP)) < 0) {
 #endif /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */
         mender_log_error("Unable to create socket, result = %d, errno= %d", result, errno);
         ret = MENDER_FAIL;
@@ -148,18 +148,18 @@ mender_net_connect(const char *host, const char *port, int *sock) {
     sec_tag_t sec_tag[] = {
         CONFIG_MENDER_NET_CA_CERTIFICATE_TAG,
     };
-    if ((result = setsockopt(*sock, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag, sizeof(sec_tag))) < 0) {
+    if ((result = zsock_setsockopt(*sock, SOL_TLS, TLS_SEC_TAG_LIST, sec_tag, sizeof(sec_tag))) < 0) {
         mender_log_error("Unable to set TLS_SEC_TAG_LIST option, result = %d, errno = %d", result, errno);
-        close(*sock);
+        zsock_close(*sock);
         *sock = -1;
         ret   = MENDER_FAIL;
         goto END;
     }
 
     /* Set TLS_HOSTNAME option */
-    if ((result = setsockopt(*sock, SOL_TLS, TLS_HOSTNAME, host, strlen(host))) < 0) {
+    if ((result = zsock_setsockopt(*sock, SOL_TLS, TLS_HOSTNAME, host, strlen(host))) < 0) {
         mender_log_error("Unable to set TLS_HOSTNAME option, result = %d, errno = %d", result, errno);
-        close(*sock);
+        zsock_close(*sock);
         *sock = -1;
         ret   = MENDER_FAIL;
         goto END;
@@ -167,9 +167,9 @@ mender_net_connect(const char *host, const char *port, int *sock) {
 
     /* Set TLS_PEER_VERIFY option */
     int verify = CONFIG_MENDER_NET_TLS_PEER_VERIFY;
-    if ((result = setsockopt(*sock, SOL_TLS, TLS_PEER_VERIFY, &verify, sizeof(int))) < 0) {
+    if ((result = zsock_setsockopt(*sock, SOL_TLS, TLS_PEER_VERIFY, &verify, sizeof(int))) < 0) {
         mender_log_error("Unable to set TLS_PEER_VERIFY option, result = %d, errno = %d", result, errno);
-        close(*sock);
+        zsock_close(*sock);
         *sock = -1;
         ret   = MENDER_FAIL;
         goto END;
@@ -178,9 +178,10 @@ mender_net_connect(const char *host, const char *port, int *sock) {
 #endif /* CONFIG_NET_SOCKETS_SOCKOPT_TLS */
 
     /* Connect to the host */
-    if (0 != (result = connect(*sock, addr->ai_addr, addr->ai_addrlen))) {
+    if (0 != (result = zsock_connect(*sock, addr->ai_addr, addr->ai_addrlen))) {
         mender_log_error("Unable to connect to the host '%s:%s', result = %d, errno = %d", host, port, result, errno);
-        close(*sock);
+        mender_log_error("result = %d, errno = %d", result, errno);
+        zsock_close(*sock);
         *sock = -1;
         ret   = MENDER_FAIL;
         goto END;
@@ -190,7 +191,7 @@ END:
 
     /* Release memory */
     if (NULL != addr) {
-        freeaddrinfo(addr);
+        zsock_freeaddrinfo(addr);
     }
 
     return ret;
@@ -200,7 +201,7 @@ mender_err_t
 mender_net_disconnect(int sock) {
 
     /* Close socket */
-    close(sock);
+    zsock_close(sock);
 
     return MENDER_OK;
 }

--- a/tests/mocks/zephyr/include/zephyr/net/socket.h
+++ b/tests/mocks/zephyr/include/zephyr/net/socket.h
@@ -9,7 +9,7 @@
 #define TLS_HOSTNAME     2
 #define TLS_PEER_VERIFY  5
 
-struct addrinfo {
+struct zsock_addrinfo {
     int              ai_family;
     int              ai_socktype;
     int              ai_protocol;
@@ -17,11 +17,11 @@ struct addrinfo {
     struct sockaddr *ai_addr;
 };
 
-int  socket(int family, int type, int proto);
-int  connect(int sock, const struct sockaddr *addr, socklen_t addrlen);
-int  setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen);
-int  getaddrinfo(const char *host, const char *service, const struct addrinfo *hints, struct addrinfo **res);
-void freeaddrinfo(struct addrinfo *ai);
-int  close(int sock);
+int  zsock_socket(int family, int type, int proto);
+int  zsock_connect(int sock, const struct sockaddr *addr, socklen_t addrlen);
+int  zsock_setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen);
+int  zsock_getaddrinfo(const char *host, const char *service, const struct zsock_addrinfo *hints, struct zsock_addrinfo **res);
+void zsock_freeaddrinfo(struct zsock_addrinfo *ai);
+int  zsock_close(int sock);
 
 #endif /* __SOCKET_H__ */

--- a/tests/mocks/zephyr/src/socket.c
+++ b/tests/mocks/zephyr/src/socket.c
@@ -1,30 +1,30 @@
 #include <zephyr/net/socket.h>
 
 int
-socket(int family, int type, int proto) {
+zsock_socket(int family, int type, int proto) {
     return 0;
 }
 
 int
-connect(int sock, const struct sockaddr *addr, socklen_t addrlen) {
+zsock_connect(int sock, const struct sockaddr *addr, socklen_t addrlen) {
     return 0;
 }
 
 int
-setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen) {
+zsock_setsockopt(int sock, int level, int optname, const void *optval, socklen_t optlen) {
     return 0;
 }
 
 int
-getaddrinfo(const char *host, const char *service, const struct addrinfo *hints, struct addrinfo **res) {
+zsock_getaddrinfo(const char *host, const char *service, const struct zsock_addrinfo *hints, struct zsock_addrinfo **res) {
     return 0;
 }
 
 void
-freeaddrinfo(struct addrinfo *ai) {
+zsock_freeaddrinfo(struct zsock_addrinfo *ai) {
 }
 
 int
-close(int sock) {
+zsock_close(int sock) {
     return 0;
 }

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -39,7 +39,6 @@ menuconfig MENDER_MCU_CLIENT
     select NETWORKING
     select NET_TCP
     select NET_SOCKETS
-    select NET_SOCKETS_POSIX_NAMES
     select REBOOT
     select STREAM_FLASH
     select WEBSOCKET_CLIENT if MENDER_CLIENT_ADD_ON_TROUBLESHOOT


### PR DESCRIPTION
The purpose of this Pull Request is to remove usage of posix functions in the platform network zephyr implementation, and prefer zephyr native apis. This remove the dependency to `CONFIG_NET_SOCKETS_POSIX_NAMES`.