### PR TITLE
Improve Zephyr CMakeLists.txt file

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -24,8 +24,6 @@
 # SOFTWARE.
 
 if(CONFIG_MENDER_MCU_CLIENT)
-    zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../include")
-    zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../platform/net/zephyr/include")
     zephyr_library()
     zephyr_library_sources(
         "${CMAKE_CURRENT_LIST_DIR}/../core/src/mender-api.c"
@@ -35,7 +33,7 @@ if(CONFIG_MENDER_MCU_CLIENT)
         "${CMAKE_CURRENT_LIST_DIR}/../platform/flash/${CONFIG_MENDER_PLATFORM_FLASH_TYPE}/src/mender-flash.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/log/${CONFIG_MENDER_PLATFORM_LOG_TYPE}/src/mender-log.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-http.c"
-        "${CMAKE_CURRENT_LIST_DIR}/../platform/net/zephyr/src/mender-net.c"
+        "${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-net.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/rtos/${CONFIG_MENDER_PLATFORM_RTOS_TYPE}/src/mender-rtos.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/storage/${CONFIG_MENDER_PLATFORM_STORAGE_TYPE}/src/mender-storage.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/tls/${CONFIG_MENDER_PLATFORM_TLS_TYPE}/src/mender-tls.c"
@@ -51,6 +49,8 @@ if(CONFIG_MENDER_MCU_CLIENT)
         "${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/src/mender-websocket.c"
         "${CMAKE_CURRENT_LIST_DIR}/../platform/shell/zephyr/src/mender-shell.c"
     )
+    zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../include")
+    zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/include")
     file (STRINGS "${CMAKE_CURRENT_LIST_DIR}/../VERSION" MENDER_CLIENT_VERSION)
-    add_definitions("-DMENDER_CLIENT_VERSION=\"${MENDER_CLIENT_VERSION}\"")
+    zephyr_library_compile_definitions(-DMENDER_CLIENT_VERSION=\"${MENDER_CLIENT_VERSION}\")
 endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -53,4 +53,5 @@ if(CONFIG_MENDER_MCU_CLIENT)
     zephyr_include_directories("${CMAKE_CURRENT_LIST_DIR}/../platform/net/${CONFIG_MENDER_PLATFORM_NET_TYPE}/include")
     file (STRINGS "${CMAKE_CURRENT_LIST_DIR}/../VERSION" MENDER_CLIENT_VERSION)
     zephyr_library_compile_definitions(-DMENDER_CLIENT_VERSION=\"${MENDER_CLIENT_VERSION}\")
+    zephyr_library_compile_definitions(-D_POSIX_C_SOURCE=200809L)  # Required for strdup and strtok_r support
 endif()

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -54,4 +54,5 @@ if(CONFIG_MENDER_MCU_CLIENT)
     file (STRINGS "${CMAKE_CURRENT_LIST_DIR}/../VERSION" MENDER_CLIENT_VERSION)
     zephyr_library_compile_definitions(-DMENDER_CLIENT_VERSION=\"${MENDER_CLIENT_VERSION}\")
     zephyr_library_compile_definitions(-D_POSIX_C_SOURCE=200809L)  # Required for strdup and strtok_r support
+    zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)
 endif()


### PR DESCRIPTION
The purpose of this Pull Request is to improve Zephyr CMakeLists.txt file:
- general improvements
- Definition of _POSIX_C_SOURCE, required to support latest Zephyr version (3.6.99)
- Link to mbedTLS library if required, required to support latest Zephyr version (3.6.99)