### PR TITLE
client: allow custom identity instead of using mac address by default

### DIFF
--- a/include/mender-api.h
+++ b/include/mender-api.h
@@ -38,11 +38,11 @@ extern "C" {
  * @brief Mender API configuration
  */
 typedef struct {
-    char *mac_address;   /**< MAC address of the device */
-    char *artifact_name; /**< Artifact name */
-    char *device_type;   /**< Device type */
-    char *host;          /**< URL of the mender server */
-    char *tenant_token;  /**< Tenant token used to authenticate on the mender server (optional) */
+    mender_keystore_t *identity;      /**< Identity of the device */
+    char *             artifact_name; /**< Artifact name */
+    char *             device_type;   /**< Device type */
+    char *             host;          /**< URL of the mender server */
+    char *             tenant_token;  /**< Tenant token used to authenticate on the mender server (optional) */
 } mender_api_config_t;
 
 /**

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -38,14 +38,14 @@ extern "C" {
  * @brief Mender client configuration
  */
 typedef struct {
-    char *  mac_address;                  /**< MAC address of the device */
-    char *  artifact_name;                /**< Artifact name */
-    char *  device_type;                  /**< Device type */
-    char *  host;                         /**< URL of the mender server */
-    char *  tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
-    int32_t authentication_poll_interval; /**< Authentication poll interval, default is 60 seconds, -1 permits to disable periodic execution */
-    int32_t update_poll_interval;         /**< Update poll interval, default is 1800 seconds, -1 permits to disable periodic execution */
-    bool    recommissioning;              /**< Used to force creation of new authentication keys */
+    mender_keystore_t *identity;                     /**< Identity of the device */
+    char *             artifact_name;                /**< Artifact name */
+    char *             device_type;                  /**< Device type */
+    char *             host;                         /**< URL of the mender server */
+    char *             tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
+    int32_t            authentication_poll_interval; /**< Authentication poll interval, default is 60 seconds, -1 permits to disable periodic execution */
+    int32_t            update_poll_interval;         /**< Update poll interval, default is 1800 seconds, -1 permits to disable periodic execution */
+    bool               recommissioning;              /**< Used to force creation of new authentication keys */
 } mender_client_config_t;
 
 /**

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -358,7 +358,8 @@ main(int argc, char **argv) {
     }
 
     /* Initialize mender-client */
-    mender_client_config_t    mender_client_config    = { .mac_address                  = mac_address,
+    mender_keystore_t         identity[]              = { { .name = "mac", .value = mac_address }, { .name = NULL, .value = NULL } };
+    mender_client_config_t    mender_client_config    = { .identity                     = identity,
                                                     .artifact_name                = artifact_name,
                                                     .device_type                  = device_type,
                                                     .host                         = NULL,


### PR DESCRIPTION
The purpose of this Pull Request is to allow using a custom identity instead of forcing only the mac address. This permit to use any field in the identity.