### PR TITLE
core: utils: remove str replace function from the client library

### DIFF
--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -25,8 +25,6 @@
  * SOFTWARE.
  */
 
-#include <sys/types.h>
-#include <regex.h>
 #include "mender-log.h"
 
 char *
@@ -145,98 +143,6 @@ mender_utils_strendwith(const char *s1, const char *s2) {
 
     /* Compare the end of the string */
     return (0 == strncmp(s1 + strlen(s1) - strlen(s2), s2, strlen(s2)));
-}
-
-char *
-mender_utils_str_replace(char *input, char *search, char *replace) {
-
-    assert(NULL != input);
-    assert(NULL != search);
-    assert(NULL != replace);
-
-    regex_t    regex;
-    regmatch_t match;
-    char *     str                   = input;
-    char *     output                = NULL;
-    size_t     index                 = 0;
-    int        previous_match_finish = 0;
-
-    /* Compile expression */
-    if (0 != regcomp(&regex, search, REG_EXTENDED)) {
-        /* Unable to compile expression */
-        mender_log_error("Unable to compile expression '%s'", search);
-        return NULL;
-    }
-
-    /* Loop until all search string are replaced */
-    bool loop = true;
-    while (true == loop) {
-
-        /* Search wanted string */
-        if (0 != regexec(&regex, str, 1, &match, 0)) {
-            /* No more string to be replaced */
-            loop = false;
-        } else {
-            if (match.rm_so != -1) {
-
-                /* Beginning and ending offset of the match */
-                int current_match_start  = (int)(match.rm_so + (str - input));
-                int current_match_finish = (int)(match.rm_eo + (str - input));
-
-                /* Reallocate output memory */
-                char *tmp = (char *)realloc(output, index + (current_match_start - previous_match_finish) + 1);
-                if (NULL == tmp) {
-                    mender_log_error("Unable to allocate memory");
-                    regfree(&regex);
-                    free(output);
-                    return NULL;
-                }
-                output = tmp;
-
-                /* Copy string from previous match to the beginning of the current match */
-                memcpy(&output[index], &input[previous_match_finish], current_match_start - previous_match_finish);
-                index += (current_match_start - previous_match_finish);
-                output[index] = 0;
-
-                /* Reallocate output memory */
-                if (NULL == (tmp = (char *)realloc(output, index + strlen(replace) + 1))) {
-                    mender_log_error("Unable to allocate memory");
-                    regfree(&regex);
-                    free(output);
-                    return NULL;
-                }
-                output = tmp;
-
-                /* Copy replace string to the output */
-                strcat(output, replace);
-                index += strlen(replace);
-
-                /* Update previous match ending value */
-                previous_match_finish = current_match_finish;
-            }
-            str += match.rm_eo;
-        }
-    }
-
-    /* Reallocate output memory */
-    char *tmp = (char *)realloc(output, index + (strlen(input) - previous_match_finish) + 1);
-    if (NULL == tmp) {
-        mender_log_error("Unable to allocate memory");
-        regfree(&regex);
-        free(output);
-        return NULL;
-    }
-    output = tmp;
-
-    /* Copy the end of the string after the latest match */
-    memcpy(&output[index], &input[previous_match_finish], strlen(input) - previous_match_finish);
-    index += (strlen(input) - previous_match_finish);
-    output[index] = 0;
-
-    /* Release regex */
-    regfree(&regex);
-
-    return output;
 }
 
 char *

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -116,15 +116,6 @@ bool mender_utils_strbeginwith(const char *s1, const char *s2);
 bool mender_utils_strendwith(const char *s1, const char *s2);
 
 /**
- * @brief Function used to replace a string in the input buffer
- * @param input Input buffer
- * @param search String to be replaced or regex expression
- * @param replace Replacement string
- * @return New string with replacements if the function succeeds, NULL otherwise
- */
-char *mender_utils_str_replace(char *input, char *search, char *replace);
-
-/**
  * @brief Function used to create a key-store
  * @param length Length of the key-store
  * @return Key-store if the function succeeds, NULL otherwise

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -26,9 +26,10 @@
  */
 
 #include <getopt.h>
-#include <stdio.h>
 #include <pthread.h>
+#include <regex.h>
 #include <signal.h>
+#include <stdio.h>
 #include "mender-client.h"
 #include "mender-configure.h"
 #include "mender-flash.h"
@@ -200,6 +201,105 @@ shell_resize_cb(uint16_t terminal_width, uint16_t terminal_height) {
 }
 
 /**
+ * @brief Function used to replace a string in the input buffer
+ * @param input Input buffer
+ * @param search String to be replaced or regex expression
+ * @param replace Replacement string
+ * @return New string with replacements if the function succeeds, NULL otherwise
+ */
+static char *
+str_replace(char *input, char *search, char *replace) {
+
+    assert(NULL != input);
+    assert(NULL != search);
+    assert(NULL != replace);
+
+    regex_t    regex;
+    regmatch_t match;
+    char *     str                   = input;
+    char *     output                = NULL;
+    size_t     index                 = 0;
+    int        previous_match_finish = 0;
+
+    /* Compile expression */
+    if (0 != regcomp(&regex, search, REG_EXTENDED)) {
+        /* Unable to compile expression */
+        mender_log_error("Unable to compile expression '%s'", search);
+        return NULL;
+    }
+
+    /* Loop until all search string are replaced */
+    bool loop = true;
+    while (true == loop) {
+
+        /* Search wanted string */
+        if (0 != regexec(&regex, str, 1, &match, 0)) {
+            /* No more string to be replaced */
+            loop = false;
+        } else {
+            if (match.rm_so != -1) {
+
+                /* Beginning and ending offset of the match */
+                int current_match_start  = (int)(match.rm_so + (str - input));
+                int current_match_finish = (int)(match.rm_eo + (str - input));
+
+                /* Reallocate output memory */
+                char *tmp = (char *)realloc(output, index + (current_match_start - previous_match_finish) + 1);
+                if (NULL == tmp) {
+                    mender_log_error("Unable to allocate memory");
+                    regfree(&regex);
+                    free(output);
+                    return NULL;
+                }
+                output = tmp;
+
+                /* Copy string from previous match to the beginning of the current match */
+                memcpy(&output[index], &input[previous_match_finish], current_match_start - previous_match_finish);
+                index += (current_match_start - previous_match_finish);
+                output[index] = 0;
+
+                /* Reallocate output memory */
+                if (NULL == (tmp = (char *)realloc(output, index + strlen(replace) + 1))) {
+                    mender_log_error("Unable to allocate memory");
+                    regfree(&regex);
+                    free(output);
+                    return NULL;
+                }
+                output = tmp;
+
+                /* Copy replace string to the output */
+                strcat(output, replace);
+                index += strlen(replace);
+
+                /* Update previous match ending value */
+                previous_match_finish = current_match_finish;
+            }
+            str += match.rm_eo;
+        }
+    }
+
+    /* Reallocate output memory */
+    char *tmp = (char *)realloc(output, index + (strlen(input) - previous_match_finish) + 1);
+    if (NULL == tmp) {
+        mender_log_error("Unable to allocate memory");
+        regfree(&regex);
+        free(output);
+        return NULL;
+    }
+    output = tmp;
+
+    /* Copy the end of the string after the latest match */
+    memcpy(&output[index], &input[previous_match_finish], strlen(input) - previous_match_finish);
+    index += (strlen(input) - previous_match_finish);
+    output[index] = 0;
+
+    /* Release regex */
+    regfree(&regex);
+
+    return output;
+}
+
+/**
  * @brief Shell write data callback
  * @param data Shell data received
  * @param length Length of the data received
@@ -217,7 +317,7 @@ shell_write_cb(uint8_t *data, size_t length) {
         ret = MENDER_FAIL;
         goto END;
     }
-    if (NULL == (tmp = mender_utils_str_replace(buffer, "\r|\n", "\r\n"))) {
+    if (NULL == (tmp = str_replace(buffer, "\r|\n", "\r\n"))) {
         mender_log_error("Unable to allocate memory");
         ret = MENDER_FAIL;
         goto END;


### PR DESCRIPTION
The purpose of this Pull Request is to remove mender_utils_str_replace function. It is used only for tests and specific example, not by mender-mcu-client library itself.