### PR TITLE
platform: scheduler: remove unused delay functions

### DIFF
--- a/include/mender-scheduler.h
+++ b/include/mender-scheduler.h
@@ -94,20 +94,6 @@ mender_err_t mender_scheduler_work_deactivate(void *handle);
 mender_err_t mender_scheduler_work_delete(void *handle);
 
 /**
- * @brief Function used to initialize handle to be used with mender_scheduler_delay_until_* functions
- * @param handle Delay handle
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_scheduler_delay_until_init(unsigned long *handle);
-
-/**
- * @brief Function used to make a delay until a specified time
- * @param delay Delay value (seconds)
- * @return MENDER_OK if the function succeeds, error code otherwise
- */
-mender_err_t mender_scheduler_delay_until_s(unsigned long *handle, uint32_t delay);
-
-/**
  * @brief Function used to create a mutex
  * @param handle Mutex handle if the function succeeds, NULL otherwise
  * @return MENDER_OK if the function succeeds, error code otherwise

--- a/platform/scheduler/freertos/src/mender-scheduler.c
+++ b/platform/scheduler/freertos/src/mender-scheduler.c
@@ -297,26 +297,6 @@ mender_scheduler_work_delete(void *handle) {
 }
 
 mender_err_t
-mender_scheduler_delay_until_init(unsigned long *handle) {
-
-    assert(NULL != handle);
-
-    /* Get uptime */
-    *handle = (unsigned long)xTaskGetTickCount();
-
-    return MENDER_OK;
-}
-
-mender_err_t
-mender_scheduler_delay_until_s(unsigned long *handle, uint32_t delay) {
-
-    /* Sleep */
-    vTaskDelayUntil((TickType_t *)handle, (1000 * delay) / portTICK_PERIOD_MS);
-
-    return MENDER_OK;
-}
-
-mender_err_t
 mender_scheduler_mutex_create(void **handle) {
 
     assert(NULL != handle);

--- a/platform/scheduler/generic/weak/src/mender-scheduler.c
+++ b/platform/scheduler/generic/weak/src/mender-scheduler.c
@@ -91,25 +91,6 @@ mender_scheduler_work_delete(void *handle) {
 }
 
 __attribute__((weak)) mender_err_t
-mender_scheduler_delay_until_init(unsigned long *handle) {
-
-    (void)handle;
-
-    /* Nothing to do */
-    return MENDER_NOT_IMPLEMENTED;
-}
-
-__attribute__((weak)) mender_err_t
-mender_scheduler_delay_until_s(unsigned long *handle, uint32_t delay) {
-
-    (void)handle;
-    (void)delay;
-
-    /* Nothing to do */
-    return MENDER_NOT_IMPLEMENTED;
-}
-
-__attribute__((weak)) mender_err_t
 mender_scheduler_mutex_create(void **handle) {
 
     (void)handle;

--- a/platform/scheduler/posix/src/mender-scheduler.c
+++ b/platform/scheduler/posix/src/mender-scheduler.c
@@ -326,50 +326,6 @@ mender_scheduler_work_delete(void *handle) {
 }
 
 mender_err_t
-mender_scheduler_delay_until_init(unsigned long *handle) {
-
-    assert(NULL != handle);
-
-    /* Read clock */
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    *handle = (unsigned long)(now.tv_sec * 1000000 + now.tv_nsec / 1000);
-
-    return MENDER_OK;
-}
-
-mender_err_t
-mender_scheduler_delay_until_s(unsigned long *handle, uint32_t delay) {
-
-    assert(NULL != handle);
-
-    /* Compute elapsed time (amount of time since start marker) */
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    unsigned long elapsed = (now.tv_sec * 1000000 + now.tv_nsec / 1000) - *handle;
-
-    /* Time to wait is the delay - elapsed time */
-    unsigned long delay_us      = delay * 1000000;
-    unsigned long real_delay_us = (unsigned long)ceil((double)(delay_us - elapsed));
-    if ((0 < real_delay_us) && (real_delay_us <= delay_us)) {
-        struct timespec request;
-        struct timespec remaining;
-        remaining.tv_sec  = real_delay_us / 1000000;
-        remaining.tv_nsec = (real_delay_us % 1000000) * 1000;
-        do {
-            request.tv_sec  = remaining.tv_sec;
-            request.tv_nsec = remaining.tv_nsec;
-        } while (nanosleep(&request, &remaining) < 0);
-    }
-
-    /* Read clock */
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    *handle = (unsigned long)(now.tv_sec * 1000000 + now.tv_nsec / 1000);
-
-    return MENDER_OK;
-}
-
-mender_err_t
 mender_scheduler_mutex_create(void **handle) {
 
     assert(NULL != handle);

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -248,32 +248,6 @@ mender_scheduler_work_delete(void *handle) {
 }
 
 mender_err_t
-mender_scheduler_delay_until_init(unsigned long *handle) {
-
-    assert(NULL != handle);
-
-    /* Get uptime */
-    *handle = (unsigned long)k_uptime_get();
-
-    return MENDER_OK;
-}
-
-mender_err_t
-mender_scheduler_delay_until_s(unsigned long *handle, uint32_t delay) {
-
-    assert(NULL != handle);
-
-    /* Compute sleep time and sleep */
-    int64_t ms = (1000 * delay) - (k_uptime_get() - *handle);
-    k_msleep((ms > 0) ? ((int32_t)ms) : 1);
-
-    /* Update uptime */
-    *handle = (unsigned long)k_uptime_get();
-
-    return MENDER_OK;
-}
-
-mender_err_t
 mender_scheduler_mutex_create(void **handle) {
 
     assert(NULL != handle);


### PR DESCRIPTION
The purpose of this Pull Request is to remove unused function in the platform scheduler APIs.