### PR TITLE
client: rework apis so that the mender-client registers add-ons and manage them

### DIFF
--- a/add-ons/src/mender-troubleshoot.c
+++ b/add-ons/src/mender-troubleshoot.c
@@ -54,6 +54,12 @@
 #define MENDER_TROUBLESHOOT_SBUFFER_INIT_SIZE (256)
 
 /**
+ * @brief Mender troubleshoot instance
+ */
+const mender_addon_instance_t mender_troubleshoot_addon_instance
+    = { .init = mender_troubleshoot_init, .activate = NULL, .deactivate = mender_troubleshoot_deactivate, .exit = mender_troubleshoot_exit };
+
+/**
  * Proto type
  */
 typedef enum {
@@ -297,20 +303,22 @@ static void mender_troubleshoot_release_protohdr(mender_troubleshoot_protohdr_t 
 static void mender_troubleshoot_release_protohdr_properties(mender_troubleshoot_protohdr_properties_t *properties);
 
 mender_err_t
-mender_troubleshoot_init(mender_troubleshoot_config_t *config, mender_troubleshoot_callbacks_t *callbacks) {
+mender_troubleshoot_init(void *config, void *callbacks) {
 
     assert(NULL != config);
     mender_err_t ret;
 
     /* Save configuration */
-    if (0 != config->healthcheck_interval) {
-        mender_troubleshoot_config.healthcheck_interval = config->healthcheck_interval;
+    if (0 != ((mender_troubleshoot_config_t *)config)->healthcheck_interval) {
+        mender_troubleshoot_config.healthcheck_interval = ((mender_troubleshoot_config_t *)config)->healthcheck_interval;
     } else {
         mender_troubleshoot_config.healthcheck_interval = CONFIG_MENDER_CLIENT_TROUBLESHOOT_HEALTHCHECK_INTERVAL;
     }
 
     /* Save callbacks */
-    memcpy(&mender_troubleshoot_callbacks, callbacks, sizeof(mender_troubleshoot_callbacks_t));
+    if (NULL != callbacks) {
+        memcpy(&mender_troubleshoot_callbacks, callbacks, sizeof(mender_troubleshoot_callbacks_t));
+    }
 
     /* Create troubleshoot healthcheck work */
     mender_scheduler_work_params_t healthcheck_work_params;

--- a/include/mender-addon.h
+++ b/include/mender-addon.h
@@ -1,0 +1,51 @@
+/**
+ * @file      mender-addon.h
+ * @brief     Mender MCU addon implementation
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 joelguittet and mender-mcu-client contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __MENDER_ADDON_H__
+#define __MENDER_ADDON_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "mender-utils.h"
+
+/**
+ * @brief Mender add-on instance
+ */
+typedef struct {
+    mender_err_t (*init)(void *, void *); /**< Invoked to initialize the add-on */
+    mender_err_t (*activate)(void);       /**< Invoked to activate the add-on */
+    mender_err_t (*deactivate)(void);     /**< Invoked to deactivate the add-on */
+    mender_err_t (*exit)(void);           /**< Invoked to cleanup the add-on */
+} mender_addon_instance_t;
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __MENDER_ADDON_H__ */

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include "mender-addon.h"
 #include "mender-utils.h"
 
 /**
@@ -84,6 +85,28 @@ mender_err_t mender_client_register_artifact_type(char *type,
                                                   mender_err_t (*callback)(char *, char *, char *, cJSON *, char *, size_t, void *, size_t, size_t),
                                                   bool  needs_restart,
                                                   char *artifact_name);
+
+/**
+ * @brief Register add-on
+ * @param addon Add-on
+ * @param config Add-on configuration
+ * @param callbacks Add-on callbacks
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_register_addon(mender_addon_instance_t *addon, void *config, void *callbacks);
+
+/**
+ * @brief Activate mender client
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_activate(void);
+
+/**
+ * @brief Deactivate mender client
+ * @note This function stops synchronization with the server
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_client_deactivate(void);
 
 /**
  * @brief Function used to trigger execution of the authentication and update work

--- a/include/mender-configure.h
+++ b/include/mender-configure.h
@@ -32,9 +32,15 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include "mender-addon.h"
 #include "mender-utils.h"
 
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_CONFIGURE
+
+/**
+ * @brief Mender configure instance
+ */
+extern const mender_addon_instance_t mender_configure_addon_instance;
 
 /**
  * @brief Mender configure configuration
@@ -55,16 +61,23 @@ typedef struct {
 /**
  * @brief Initialize mender configure add-on
  * @param config Mender configure configuration
- * @param callbacks Mender configure callbacks
+ * @param callbacks Mender configure callbacks (optional)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_configure_init(mender_configure_config_t *config, mender_configure_callbacks_t *callbacks);
+mender_err_t mender_configure_init(void *config, void *callbacks);
 
 /**
  * @brief Activate mender configure add-on
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_configure_activate(void);
+
+/**
+ * @brief Deactivate mender configure add-on
+ * @note This function stops synchronization with the server
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_configure_deactivate(void);
 
 /**
  * @brief Get mender configuration

--- a/include/mender-inventory.h
+++ b/include/mender-inventory.h
@@ -32,9 +32,15 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include "mender-addon.h"
 #include "mender-utils.h"
 
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_INVENTORY
+
+/**
+ * @brief Mender inventory instance
+ */
+extern const mender_addon_instance_t mender_inventory_addon_instance;
 
 /**
  * @brief Mender inventory configuration
@@ -46,15 +52,23 @@ typedef struct {
 /**
  * @brief Initialize mender inventory add-on
  * @param config Mender inventory configuration
+ * @param callbacks Mender inventory callbacks (not used)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_inventory_init(mender_inventory_config_t *config);
+mender_err_t mender_inventory_init(void *config, void *callbacks);
 
 /**
  * @brief Activate mender inventory add-on
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_inventory_activate(void);
+
+/**
+ * @brief Deactivate mender inventory add-on
+ * @note This function stops synchronization with the server
+ * @return MENDER_OK if the function succeeds, error code otherwise
+ */
+mender_err_t mender_inventory_deactivate(void);
 
 /**
  * @brief Set mender inventory

--- a/include/mender-troubleshoot.h
+++ b/include/mender-troubleshoot.h
@@ -32,9 +32,15 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include "mender-addon.h"
+#include "mender-utils.h"
+
 #ifdef CONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
-#include "mender-utils.h"
+/**
+ * @brief Mender troubleshoot instance
+ */
+extern const mender_addon_instance_t mender_troubleshoot_addon_instance;
 
 /**
  * @brief Mender troubleshoot configuration
@@ -56,10 +62,10 @@ typedef struct {
 /**
  * @brief Initialize mender troubleshoot add-on
  * @param config Mender troubleshoot configuration
- * @param callbacks Mender troubleshoot callbacks
+ * @param callbacks Mender troubleshoot callbacks (optional)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_troubleshoot_init(mender_troubleshoot_config_t *config, mender_troubleshoot_callbacks_t *callbacks);
+mender_err_t mender_troubleshoot_init(void *config, void *callbacks);
 
 /**
  * @brief Activate mender troubleshoot add-on


### PR DESCRIPTION
The purpose of this Pull Request is to improve management of add-ons giving the control to the mender client itself instead of relying on user application.

A new function `mender_client_register_addon` is introduced to register the wanted add-on to the mender client. It will then manage init/activation/deactivation/exit for each add-on.

Particularly, the inventory and configure add-ons are now only managed by mender-client. Only the mender-troubleshoot add-on has an optional activation still controlled by the user application (because this mean connecting to the network and keeping the connection opened, so it's better to let control).

This enhancement permits additional user custom add-ons to be created and registered to the mender-client, for example to manage specific artifact types.