### PR TITLE
core: client: add network connect/disconnect callbacks

### DIFF
--- a/add-ons/src/mender-troubleshoot.c
+++ b/add-ons/src/mender-troubleshoot.c
@@ -383,6 +383,9 @@ mender_troubleshoot_deactivate(void) {
             mender_log_error("Unable to disconnect the device of the server");
         }
         mender_troubleshoot_handle = NULL;
+
+        /* Release access to the network */
+        mender_client_network_release();
     }
 
     /* Release session ID */
@@ -511,6 +514,12 @@ mender_troubleshoot_healthcheck_work_function(void) {
 
     } else {
 
+        /* Request access to the network */
+        if (MENDER_OK != (ret = mender_client_network_connect())) {
+            mender_log_error("Requesting access to the network failed");
+            goto END;
+        }
+
         /* Connect the device to the server */
         if (MENDER_OK != (ret = mender_api_troubleshoot_connect(&mender_troubleshoot_data_received_callback, &mender_troubleshoot_handle))) {
             mender_log_error("Unable to connect the device to the server");
@@ -541,6 +550,9 @@ FAIL:
             mender_log_error("Unable to disconnect the device of the server");
         }
         mender_troubleshoot_handle = NULL;
+
+        /* Release access to the network */
+        mender_client_network_release();
     }
 
     /* Release session ID */

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -53,6 +53,8 @@ typedef struct {
  * @brief Mender client callbacks
  */
 typedef struct {
+    mender_err_t (*network_connect)(void);                                 /**< Invoked when mender-client requests access to the network */
+    mender_err_t (*network_release)(void);                                 /**< Invoked when mender-client releases access to the network */
     mender_err_t (*authentication_success)(void);                          /**< Invoked when authentication with the mender server succeeded */
     mender_err_t (*authentication_failure)(void);                          /**< Invoked when authentication with the mender server failed */
     mender_err_t (*deployment_status)(mender_deployment_status_t, char *); /**< Invoked on transition changes to inform of the new deployment status */
@@ -115,6 +117,18 @@ mender_err_t mender_client_deactivate(void);
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_client_execute(void);
+
+/**
+ * @brief Function to be called from add-ons to request network access
+ * @return MENDER_OK if network is connected following the request, error code otherwise
+ */
+mender_err_t mender_client_network_connect(void);
+
+/**
+ * @brief Function to be called from add-ons to release network access
+ * @return MENDER_OK if network is released following the request, error code otherwise
+ */
+mender_err_t mender_client_network_release(void);
 
 /**
  * @brief Release mender client

--- a/tests/src/main.c
+++ b/tests/src/main.c
@@ -50,6 +50,38 @@ static pthread_mutex_t mender_client_events_mutex;
 static pthread_cond_t  mender_client_events_cond;
 
 /**
+ * @brief Network connnect callback
+ * @return MENDER_OK if network is connected following the request, error code otherwise
+ */
+static mender_err_t
+network_connect_cb(void) {
+
+    mender_log_info("Mender client connect network");
+
+    /* This callback can be used to configure network connection */
+    /* Note that the application can connect the network before if required */
+    /* This callback only indicates the mender-client requests network access now */
+    /* Nothing to do in this test application just return network is available */
+    return MENDER_OK;
+}
+
+/**
+ * @brief Network release callback
+ * @return MENDER_OK if network is released following the request, error code otherwise
+ */
+static mender_err_t
+network_release_cb(void) {
+
+    mender_log_info("Mender client released network");
+
+    /* This callback can be used to release network connection */
+    /* Note that the application can keep network activated if required */
+    /* This callback only indicates the mender-client doesn't request network access now */
+    /* Nothing to do in this test application just return network is released */
+    return MENDER_OK;
+}
+
+/**
  * @brief Authentication success callback
  * @return MENDER_OK if application is marked valid and success deployment status should be reported to the server, error code otherwise
  */
@@ -454,7 +486,9 @@ main(int argc, char **argv) {
                                                     .authentication_poll_interval = 0,
                                                     .update_poll_interval         = 0,
                                                     .recommissioning              = false };
-    mender_client_callbacks_t mender_client_callbacks = { .authentication_success = authentication_success_cb,
+    mender_client_callbacks_t mender_client_callbacks = { .network_connect        = network_connect_cb,
+                                                          .network_release        = network_release_cb,
+                                                          .authentication_success = authentication_success_cb,
                                                           .authentication_failure = authentication_failure_cb,
                                                           .deployment_status      = deployment_status_cb,
                                                           .restart                = restart_cb };


### PR DESCRIPTION
The purpose of this Pull Request it to add network connect/disconnect callback in the mender client so that the mender client can indicate when the network access is required, and when it can be released. This can be used to close network connection when it is not required.