### PR TITLE
Fix a bunch of typos in core and include files

### DIFF
--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -870,7 +870,7 @@ mender_api_websocket_callback(mender_websocket_client_event_t event, void *data,
             mender_log_info("Troubleshoot client disconnected");
             break;
         case MENDER_WEBSOCKET_EVENT_ERROR:
-            /* Websocket conection fails */
+            /* Websocket connection fails */
             mender_log_error("An error occurred");
             ret = MENDER_FAIL;
             break;

--- a/core/src/mender-artifact.c
+++ b/core/src/mender-artifact.c
@@ -64,28 +64,28 @@ typedef struct {
 /**
  * @brief Parse header of TAR file
  * @param ctx Artifact context
- * @return MENDER_DONE if the data have been parsed, MENDER_OK if there is not enougth data to parse, error code if an error occured
+ * @return MENDER_DONE if the data have been parsed, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
 static mender_err_t mender_artifact_parse_tar_header(mender_artifact_ctx_t *ctx);
 
 /**
  * @brief Check version file of the artifact
  * @param ctx Artifact context
- * @return MENDER_DONE if the data have been parsed and version verified, MENDER_OK if there is not enougth data to parse, error code if an error occured
+ * @return MENDER_DONE if the data have been parsed and version verified, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
 static mender_err_t mender_artifact_check_version(mender_artifact_ctx_t *ctx);
 
 /**
  * @brief Read header-info file of the artifact
  * @param ctx Artifact context
- * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enougth data to parse, error code if an error occured
+ * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
 static mender_err_t mender_artifact_read_header_info(mender_artifact_ctx_t *ctx);
 
 /**
  * @brief Read meta-data file of the artifact
  * @param ctx Artifact context
- * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enougth data to parse, error code if an error occured
+ * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
 static mender_err_t mender_artifact_read_meta_data(mender_artifact_ctx_t *ctx);
 
@@ -93,14 +93,14 @@ static mender_err_t mender_artifact_read_meta_data(mender_artifact_ctx_t *ctx);
  * @brief Read data file of the artifact
  * @param ctx Artifact context
  * @param callback Callback function to be invoked to perform the treatment of the data from the artifact
- * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enougth data to parse, error code if an error occured
+ * @return MENDER_DONE if the data have been parsed and payloads retrieved, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
 static mender_err_t mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(char *, cJSON *, char *, size_t, void *, size_t, size_t));
 
 /**
  * @brief Drop content of the current file of the artifact
  * @param ctx Artifact context
- * @return MENDER_DONE if the data have been parsed and dropped, MENDER_OK if there is not enougth data to parse, error code if an error occured
+ * @return MENDER_DONE if the data have been parsed and dropped, MENDER_OK if there is not enough data to parse, error code if an error occurred
  */
 static mender_err_t mender_artifact_drop_file(mender_artifact_ctx_t *ctx);
 
@@ -113,7 +113,7 @@ static mender_err_t mender_artifact_drop_file(mender_artifact_ctx_t *ctx);
 static mender_err_t mender_artifact_shift_data(mender_artifact_ctx_t *ctx, size_t length);
 
 /**
- * @brief Compute length rounded up to increment (usualy the block size)
+ * @brief Compute length rounded up to increment (usually the block size)
  * @param length Length
  * @param incr Increment
  * @return Rounded length
@@ -255,7 +255,7 @@ mender_artifact_parse_tar_header(mender_artifact_ctx_t *ctx) {
     assert(NULL != ctx);
     char *tmp;
 
-    /* Check if enought data are received (at least one block) */
+    /* Check if enough data are received (at least one block) */
     if ((NULL == ctx->input.data) || (ctx->input.length < MENDER_ARTIFACT_STREAM_BLOCK_SIZE)) {
         return MENDER_OK;
     }
@@ -266,7 +266,7 @@ mender_artifact_parse_tar_header(mender_artifact_ctx_t *ctx) {
     /* Check if file name is provided, else the end of the current TAR file is reached */
     if ('\0' == tar_header->name[0]) {
 
-        /* Check if enought data are received (at least 2 blocks) */
+        /* Check if enough data are received (at least 2 blocks) */
         if (ctx->input.length < 2 * MENDER_ARTIFACT_STREAM_BLOCK_SIZE) {
             return MENDER_OK;
         }
@@ -533,9 +533,9 @@ mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(c
     /* Check if a file name is provided (we don't check the extension because we don't know it) */
     if (strlen("data/xxxx.tar") == strlen(ctx->file.name)) {
 
-        /* Begining of the data file */
+        /* Beginning of the data file */
         if (MENDER_OK != (ret = callback(ctx->payloads.values[index].type, ctx->payloads.values[index].meta_data, NULL, 0, NULL, 0, 0))) {
-            mender_log_error("An error occured");
+            mender_log_error("An error occurred");
             return ret;
         }
 
@@ -551,7 +551,7 @@ mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(c
     /* Parse data until the end of the file has been reached */
     do {
 
-        /* Check if enought data are received (at least one block) */
+        /* Check if enough data are received (at least one block) */
         if ((NULL == ctx->input.data) || (ctx->input.length < MENDER_ARTIFACT_STREAM_BLOCK_SIZE)) {
             return MENDER_OK;
         }
@@ -569,7 +569,7 @@ mender_artifact_read_data(mender_artifact_ctx_t *ctx, mender_err_t (*callback)(c
                                ctx->input.data,
                                ctx->file.index,
                                length))) {
-            mender_log_error("An error occured");
+            mender_log_error("An error occurred");
             return ret;
         }
 
@@ -602,7 +602,7 @@ mender_artifact_drop_file(mender_artifact_ctx_t *ctx) {
     /* Parse data until the end of the file has been reached */
     do {
 
-        /* Check if enought data are received (at least one block) */
+        /* Check if enough data are received (at least one block) */
         if ((NULL == ctx->input.data) || (ctx->input.length < MENDER_ARTIFACT_STREAM_BLOCK_SIZE)) {
             return MENDER_OK;
         }

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -176,7 +176,7 @@ static mender_err_t mender_client_update_work_function(void);
  * @param data Artifact data
  * @param index Artifact data index
  * @param length Artifact data length
- * @return MENDER_OK if the function succeeds, error code if an error occured
+ * @return MENDER_OK if the function succeeds, error code if an error occurred
  */
 static mender_err_t mender_client_download_artifact_callback(
     char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length);
@@ -192,7 +192,7 @@ static mender_err_t mender_client_download_artifact_callback(
  * @param data Artifact data
  * @param index Artifact data index
  * @param length Artifact data length
- * @return MENDER_OK if the function succeeds, error code if an error occured
+ * @return MENDER_OK if the function succeeds, error code if an error occurred
  */
 static mender_err_t mender_client_download_artifact_flash_callback(
     char *id, char *artifact_name, char *type, cJSON *meta_data, char *filename, size_t size, void *data, size_t index, size_t length);

--- a/core/src/mender-utils.c
+++ b/core/src/mender-utils.c
@@ -129,7 +129,7 @@ mender_utils_strbeginwith(const char *s1, const char *s2) {
         return false;
     }
 
-    /* Compare the begining of the string */
+    /* Compare the beginning of the string */
     return (0 == strncmp(s1, s2, strlen(s2)));
 }
 

--- a/include/mender-tls.h
+++ b/include/mender-tls.h
@@ -42,14 +42,14 @@ mender_err_t mender_tls_init(void);
 
 /**
  * @brief Initialize mender TLS authentication keys
- * @param recommissioning perform recommisioning (if supported by the platform)
+ * @param recommissioning Perform recommissioning (if supported by the platform)
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_tls_init_authentication_keys(bool recommissioning);
 
 /**
  * @brief Get public key (PEM format suitable to be integrated in mender authentication request)
- * @param public_key Public key, NULL if an error occured
+ * @param public_key Public key, NULL if an error occurred
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
 mender_err_t mender_tls_get_public_key_pem(char **public_key);


### PR DESCRIPTION
Just some typos that I found while reading the code :+1: