### PR TITLE
tests: update valgrind supression file following update of the ci to uuntu-24.04

### DIFF
--- a/tests/valgrind_suppression_timer_create.supp
+++ b/tests/valgrind_suppression_timer_create.supp
@@ -3,13 +3,14 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:calloc
+   fun:calloc
    fun:allocate_dtv
    fun:_dl_allocate_tls
    fun:allocate_stack
-   fun:pthread_create@@GLIBC_2.2.5
-   fun:__start_helper_thread
+   fun:pthread_create@@GLIBC_2.34
+   fun:__timer_start_helper_thread
    fun:__pthread_once_slow
-   fun:timer_create@@GLIBC_2.3.3
+   fun:timer_create@@GLIBC_2.34
    fun:mender_scheduler_work_create
    fun:mender_client_init
    fun:main


### PR DESCRIPTION
The purpose of this Pull Request is to fix valgrind suppression file used for testing. The update is required following update to ubuntu 24.04.