### PR TITLE
Do not check if artifact is already installed

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -897,13 +897,6 @@ mender_client_update_work_function(void) {
         goto END;
     }
 
-    /* Check if artifact is already installed (should not occur) */
-    if (!strcmp(artifact_name, mender_client_config.artifact_name)) {
-        mender_log_error("Artifact is already installed");
-        mender_client_publish_deployment_status(id, MENDER_DEPLOYMENT_STATUS_ALREADY_INSTALLED);
-        goto END;
-    }
-
     /* Reset flags */
     mender_client_deployment_needs_set_pending_image = false;
     mender_client_deployment_needs_restart           = false;


### PR DESCRIPTION
The Mender Client used to check if the downloaded artifact was already installed in the past. However, this check was removed in [mendersoftware/mender@1fb6223](https://github.com/mendersoftware/mender/commit/1fb62236abdee6d2ed2452592d289320aea1bfa5) as it prevents the use of the "Force update" option, allowing a device to take part in the same deployment twice. Today, all the "already-installed" logic is performed in the backend.