### PR TITLE
add-ons: troubleshoot: fix to avoid closing file twice when an error occurred during writing

### DIFF
--- a/add-ons/troubleshoot/src/mender-troubleshoot-file-transfer.c
+++ b/add-ons/troubleshoot/src/mender-troubleshoot-file-transfer.c
@@ -854,13 +854,6 @@ mender_troubleshoot_file_transfer_chunk_message_handler(mender_troubleshoot_prot
 
 FAIL:
 
-    /* Close file */
-    if (NULL != mender_troubleshoot_file_transfer_callbacks.close) {
-        if (MENDER_OK != mender_troubleshoot_file_transfer_callbacks.close(mender_troubleshoot_file_transfer_handle)) {
-            mender_log_error("Unable to close the file");
-        }
-    }
-
     /* Format error */
     if (MENDER_OK != mender_troubleshoot_file_transfer_format_error(protomsg, &error, response)) {
         mender_log_error("Unable to format response");


### PR DESCRIPTION
The purpose of this Pull-Request is to fix a double call to close() callback when an error occurred during writing to a file.