### PR TITLE
zephyr: remove cjson and msgpack-c options

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -18,7 +18,6 @@
 menuconfig MENDER_MCU_CLIENT
     bool "Mender Firmware Over-the-Air support"
     select BOOTLOADER_MCUBOOT
-    select CJSON
     select DNS_RESOLVER
     select FLASH
     select FLASH_MAP
@@ -27,7 +26,6 @@ menuconfig MENDER_MCU_CLIENT
     select IMG_ERASE_PROGRESSIVELY
     select IMG_MANAGER
     select MPU_ALLOW_FLASH_WRITE
-    select MSGPACK_C if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
     select NETWORKING
     select NET_TCP
     select NET_SOCKETS


### PR DESCRIPTION
The purpose of this Pull-Request is to remove unknown libraries in the Zephyr Kconfig file: cJSON and msgpack-c.
These are submodule I created in the samples but they are not commonly known to be Zephyr modules. Moreover, CJSON conflicts with CJSON_LIB in nRF Connect SDK environment.

It is the responsibility of the application ot include the expected APIs:
- cJSON is always required (currently used in the core of the client)
- msgpack-c is required when building the troubleshooting add-on only.