### PR TITLE
Fix cryptoauthlib option description

### DIFF
--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -375,10 +375,10 @@ menu "Mender Firmware Over-the-Air support"
         menu "TLS options (ADVANCED)"
 
             config MENDER_TLS_PRIVATE_KEY_ID
-                int "Mender TLS PSA Crypto private key ID"
+                int "Mender TLS cryptoauthlib private key ID"
                 default 0
                 help
-                    PSA Crypto private key ID.
+                    Cryptoauthlib private key ID.
 
         endmenu
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -391,10 +391,10 @@ if MENDER_MCU_CLIENT
         menu "TLS options (ADVANCED)"
 
             config MENDER_TLS_PRIVATE_KEY_ID
-                int "Mender TLS PSA Crypto private key ID"
+                int "Mender TLS cryptoauthlib private key ID"
                 default 0
                 help
-                    PSA Crypto private key ID.
+                    Cryptoauthlib private key ID.
 
         endmenu
 


### PR DESCRIPTION
The purpose of this Pull-Request is to fix cryptoauthlib private key id description in the Kconfig fiels of esp-idf and zephyr platforms.