### PR TITLE
platform: storage: zephyr: nvs: remove redundant configuration option

### DIFF
--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -29,6 +29,7 @@
 #define MENDER_STORAGE_LABEL  storage_partition
 #define MENDER_STORAGE_DEVICE FIXED_PARTITION_DEVICE(MENDER_STORAGE_LABEL)
 #define MENDER_STORAGE_OFFSET FIXED_PARTITION_OFFSET(MENDER_STORAGE_LABEL)
+#define MENDER_STORAGE_SIZE   FIXED_PARTITION_SIZE(MENDER_STORAGE_LABEL)
 
 /**
  * @brief NVS keys
@@ -69,7 +70,7 @@ mender_storage_init(void) {
         return MENDER_FAIL;
     }
     mender_storage_nvs_handle.sector_size  = (uint16_t)info.size;
-    mender_storage_nvs_handle.sector_count = CONFIG_MENDER_STORAGE_NVS_SECTOR_COUNT;
+    mender_storage_nvs_handle.sector_count = MENDER_STORAGE_SIZE / info.size;
 
     /* Mount NVS */
     if (0 != (result = nvs_mount(&mender_storage_nvs_handle))) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,9 +74,6 @@ if(CONFIG_MENDER_PLATFORM_NET_TYPE MATCHES "zephyr")
     target_compile_definitions(mender-mcu-client PRIVATE CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_PRIMARY=1)
     target_compile_definitions(mender-mcu-client PRIVATE CONFIG_MENDER_NET_CA_CERTIFICATE_TAG_SECONDARY=2)
 endif()
-if(CONFIG_MENDER_PLATFORM_STORAGE_TYPE MATCHES "zephyr/nvs")
-    target_compile_definitions(mender-mcu-client PRIVATE CONFIG_MENDER_STORAGE_NVS_SECTOR_COUNT=4)
-endif()
 
 # Link the mender-mcu-client library
 if(CONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT)

--- a/tests/mocks/zephyr/include/zephyr/storage/flash_map.h
+++ b/tests/mocks/zephyr/include/zephyr/storage/flash_map.h
@@ -1,7 +1,8 @@
 #ifndef __FLASH_MAP_H__
 #define __FLASH_MAP_H__
 
-#define FIXED_PARTITION_OFFSET(label) 0
 #define FIXED_PARTITION_DEVICE(label) NULL
+#define FIXED_PARTITION_OFFSET(label) 0
+#define FIXED_PARTITION_SIZE(label)   0
 
 #endif /* __FLASH_MAP_H__ */

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -500,13 +500,6 @@ if MENDER_MCU_CLIENT
 
         menu "Storage options"
 
-            config MENDER_STORAGE_NVS_SECTOR_COUNT
-                int "Number of sectors of the mender_storage partition"
-                default 2
-                range 2 8
-                help
-                    Number of sectors of the mender_storage partition, must match the configuration of the partition.
-
             config MENDER_STORAGE_NVS_PRIVATE_KEY
                 int "NVS Storage private key ID"
                 default 1


### PR DESCRIPTION
The purpose of this Pull-Request is to remove the redundant configuration option `CONFIG_MENDER_STORAGE_NVS_SECTOR_COUNT`. This value can be calculated from the partition size and the sector size.