### PR TITLE
platform: modify stack size granularity from kilo-bytes to bytes

### DIFF
--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -285,9 +285,9 @@ menu "Mender Firmware Over-the-Air support"
             if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
                 config MENDER_WEBSOCKET_THREAD_STACK_SIZE
-                    int "Mender WebSocket client Thread Stack Size (kB)"
-                    range 0 64
-                    default 4
+                    int "Mender WebSocket client Thread Stack Size"
+                    range 0 65536
+                    default 4096
                     help
                         Mender WebSocket client thread stack size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
 
@@ -299,9 +299,9 @@ menu "Mender Firmware Over-the-Air support"
                         Mender WebSocket client thread priority, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
 
                 config MENDER_WEBSOCKET_BUFFER_SIZE
-                    int "Mender WebSocket Buffer Size (kB)"
-                    range 0 64
-                    default 1
+                    int "Mender WebSocket Buffer Size"
+                    range 0 65536
+                    default 1024
                     help
                         Mender WebSocket buffer size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
 
@@ -344,9 +344,9 @@ menu "Mender Firmware Over-the-Air support"
         menu "Scheduler options (ADVANCED)"
 
             config MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE
-                int "Mender Scheduler Work Queue Stack Size (kB)"
-                range 0 64
-                default 20
+                int "Mender Scheduler Work Queue Stack Size"
+                range 0 65536
+                default 20480
                 help
                     Mender scheduler work queue stack size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
                     The default TLS configuration of ESP-IDF v4.4.x allows to decrease the stack size down to 12kB.

--- a/platform/net/esp-idf/src/mender-websocket.c
+++ b/platform/net/esp-idf/src/mender-websocket.c
@@ -25,10 +25,10 @@
 #include "mender-websocket.h"
 
 /**
- * @brief Websocket thread stack size (kB)
+ * @brief Websocket thread stack size
  */
 #ifndef CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE
-#define CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE (4)
+#define CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE (4096)
 #endif /* CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE */
 
 /**
@@ -39,10 +39,10 @@
 #endif /* CONFIG_MENDER_WEBSOCKET_THREAD_PRIORITY */
 
 /**
- * @brief Websocket buffer size (kB)
+ * @brief Websocket buffer size
  */
 #ifndef CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE
-#define CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE (1)
+#define CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE (1024)
 #endif /* CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE */
 
 /**
@@ -173,9 +173,9 @@ mender_websocket_connect(
 
     /* Configuration of the client */
     esp_websocket_client_config_t config = { .uri                  = (NULL != url) ? url : path,
-                                             .task_stack           = CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE * 1024,
+                                             .task_stack           = CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE,
                                              .task_prio            = CONFIG_MENDER_WEBSOCKET_THREAD_PRIORITY,
-                                             .buffer_size          = CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE * 1024,
+                                             .buffer_size          = CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE,
                                              .user_agent           = MENDER_WEBSOCKET_USER_AGENT,
                                              .crt_bundle_attach    = esp_crt_bundle_attach,
                                              .reconnect_timeout_ms = CONFIG_MENDER_WEBSOCKET_RECONNECT_TIMEOUT,

--- a/platform/net/generic/curl/src/mender-websocket.c
+++ b/platform/net/generic/curl/src/mender-websocket.c
@@ -24,10 +24,10 @@
 #include "mender-websocket.h"
 
 /**
- * @brief Websocket thread stack size (kB)
+ * @brief Websocket thread stack size
  */
 #ifndef CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE
-#define CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE (64)
+#define CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE (65536)
 #endif /* CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE */
 
 /**
@@ -38,10 +38,10 @@
 #endif /* CONFIG_MENDER_WEBSOCKET_THREAD_PRIORITY */
 
 /**
- * @brief Websocket buffer size (kB)
+ * @brief Websocket buffer size
  */
 #ifndef CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE
-#define CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE (64)
+#define CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE (65536)
 #endif /* CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE */
 
 /**
@@ -205,8 +205,7 @@ mender_websocket_connect(
         ret = MENDER_FAIL;
         goto FAIL;
     }
-    if (CURLE_OK
-        != (err_curl = curl_easy_setopt(((mender_websocket_handle_t *)*handle)->client, CURLOPT_BUFFERSIZE, CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE * 1024))) {
+    if (CURLE_OK != (err_curl = curl_easy_setopt(((mender_websocket_handle_t *)*handle)->client, CURLOPT_BUFFERSIZE, CONFIG_MENDER_WEBSOCKET_BUFFER_SIZE))) {
         mender_log_error("Unable to set websocket receive buffer size: %s", curl_easy_strerror(err_curl));
         ret = MENDER_FAIL;
         goto FAIL;
@@ -249,8 +248,8 @@ mender_websocket_connect(
         goto FAIL;
     }
     if (0
-        != (err_pthread = pthread_attr_setstacksize(
-                &pthread_attr, ((CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE > 16) ? CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE : 16) * 1024))) {
+        != (err_pthread = pthread_attr_setstacksize(&pthread_attr,
+                                                    (CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE > 16384) ? CONFIG_MENDER_WEBSOCKET_THREAD_STACK_SIZE : 16384))) {
         mender_log_error("Unable to set websocket thread stack size (ret=%d)", err_pthread);
         ret = MENDER_FAIL;
         goto FAIL;

--- a/platform/scheduler/freertos/src/mender-scheduler.c
+++ b/platform/scheduler/freertos/src/mender-scheduler.c
@@ -32,10 +32,10 @@
 #include "mender-scheduler.h"
 
 /**
- * @brief Default work queue stack size (kB)
+ * @brief Default work queue stack size
  */
 #ifndef CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE
-#define CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE (20)
+#define CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE (20480)
 #endif /* CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE */
 
 /**
@@ -90,7 +90,7 @@ mender_scheduler_init(void) {
     if (pdPASS
         != xTaskCreate(mender_scheduler_work_queue_thread,
                        "mender_scheduler_work_queue",
-                       (configSTACK_DEPTH_TYPE)(CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE * 1024 / sizeof(configSTACK_DEPTH_TYPE)),
+                       (configSTACK_DEPTH_TYPE)(CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE / sizeof(configSTACK_DEPTH_TYPE)),
                        NULL,
                        CONFIG_MENDER_SCHEDULER_WORK_QUEUE_PRIORITY,
                        NULL)) {

--- a/platform/scheduler/posix/src/mender-scheduler.c
+++ b/platform/scheduler/posix/src/mender-scheduler.c
@@ -28,10 +28,10 @@
 #include "mender-scheduler.h"
 
 /**
- * @brief Default work queue stack size (kB)
+ * @brief Default work queue stack size
  */
 #ifndef CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE
-#define CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE (64)
+#define CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE (65536)
 #endif /* CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE */
 
 /**
@@ -109,8 +109,8 @@ mender_scheduler_init(void) {
         return MENDER_FAIL;
     }
     if (0
-        != (ret = pthread_attr_setstacksize(
-                &pthread_attr, ((CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE > 16) ? CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE : 16) * 1024))) {
+        != (ret = pthread_attr_setstacksize(&pthread_attr,
+                                            (CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE > 16384) ? CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE : 16384))) {
         mender_log_error("Unable to set work queue thread stack size (ret=%d)", ret);
         return MENDER_FAIL;
     }

--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -22,10 +22,10 @@
 #include "mender-scheduler.h"
 
 /**
- * @brief Default work queue stack size (kB)
+ * @brief Default work queue stack size
  */
 #ifndef CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE
-#define CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE (12)
+#define CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE (12288)
 #endif /* CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE */
 
 /**
@@ -49,7 +49,7 @@ typedef struct {
 /**
  * @brief Mender scheduler work queue stack
  */
-K_THREAD_STACK_DEFINE(mender_scheduler_work_queue_stack, CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE * 1024);
+K_THREAD_STACK_DEFINE(mender_scheduler_work_queue_stack, CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE);
 
 /**
  * @brief Function used to handle work context timer when it expires
@@ -75,7 +75,7 @@ mender_scheduler_init(void) {
     k_work_queue_init(&mender_scheduler_work_queue_handle);
     k_work_queue_start(&mender_scheduler_work_queue_handle,
                        mender_scheduler_work_queue_stack,
-                       CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE * 1024,
+                       CONFIG_MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE,
                        CONFIG_MENDER_SCHEDULER_WORK_QUEUE_PRIORITY,
                        NULL);
     k_thread_name_set(k_work_queue_thread_get(&mender_scheduler_work_queue_handle), "mender_scheduler_work_queue");

--- a/platform/shell/zephyr/src/mender-shell.c
+++ b/platform/shell/zephyr/src/mender-shell.c
@@ -47,10 +47,10 @@
 #endif /* CONFIG_MENDER_SHELL_TX_RING_BUFFER_SIZE */
 
 /**
- * @brief Default tx work queue stack size (kB)
+ * @brief Default tx work queue stack size
  */
 #ifndef CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE
-#define CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE (2)
+#define CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE (2048)
 #endif /* CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE */
 
 /**
@@ -91,7 +91,7 @@
 /**
  * @brief Mender RTOS work queue stack
  */
-K_THREAD_STACK_DEFINE(mender_shell_tx_work_queue_stack, CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE * 1024);
+K_THREAD_STACK_DEFINE(mender_shell_tx_work_queue_stack, CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE);
 
 /**
  * @brief Mender shell context
@@ -150,7 +150,7 @@ mender_shell_transport_api_init(const struct shell_transport *transport, const v
     k_work_queue_init(&ctx->tx_work_queue_handle);
     k_work_queue_start(&ctx->tx_work_queue_handle,
                        mender_shell_tx_work_queue_stack,
-                       CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE * 1024,
+                       CONFIG_MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE,
                        CONFIG_MENDER_SHELL_TX_WORK_QUEUE_PRIORITY,
                        NULL);
     k_thread_name_set(k_work_queue_thread_get(&ctx->tx_work_queue_handle), "mender_shell_tx_work_queue");

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -343,9 +343,9 @@ if MENDER_MCU_CLIENT
             if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
                 config MENDER_WEBSOCKET_THREAD_STACK_SIZE
-                    int "Mender WebSocket client Thread Stack Size (kB)"
-                    range 0 64
-                    default 4
+                    int "Mender WebSocket client Thread Stack Size"
+                    range 0 65536
+                    default 4096
                     help
                         Mender WebSocket client thread stack size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
 
@@ -381,9 +381,9 @@ if MENDER_MCU_CLIENT
         menu "Scheduler options (ADVANCED)"
 
             config MENDER_SCHEDULER_WORK_QUEUE_STACK_SIZE
-                int "Mender Scheduler Work Queue Stack Size (kB)"
-                range 0 64
-                default 12
+                int "Mender Scheduler Work Queue Stack Size"
+                range 0 65536
+                default 12288
                 help
                     Mender scheduler work queue stack size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
 
@@ -451,9 +451,9 @@ if MENDER_MCU_CLIENT
                     Mender Shell TX ring buffer size. Default value is suitable for most applications.
 
             config MENDER_SHELL_TX_WORK_QUEUE_STACK_SIZE
-                int "Mender Shell TX Work Queue Stack Size (kB)"
-                range 0 64
-                default 2
+                int "Mender Shell TX Work Queue Stack Size"
+                range 0 65536
+                default 2048
                 help
                     Mender Shell TX work queue stack size, customize only if you have a deep understanding of the impacts! Default value is suitable for most applications.
 


### PR DESCRIPTION
The purpose of this Pull-Request is to modify stack size granularity so that we have a better/finest control of the memory allocated. This also avoid multiple runtime multiplications to convert kilo-bytes to bytes.