### PR TITLE
platform: scheduler: zephyr: fix issue while reconfiguring timer period

### DIFF
--- a/platform/scheduler/zephyr/src/mender-scheduler.c
+++ b/platform/scheduler/zephyr/src/mender-scheduler.c
@@ -187,7 +187,7 @@ mender_scheduler_work_set_period(void *handle, uint32_t period) {
     /* Set timer period */
     work_context->params.period = period;
     if (work_context->params.period > 0) {
-        k_timer_start(&work_context->timer_handle, K_FOREVER, K_MSEC(1000 * work_context->params.period));
+        k_timer_start(&work_context->timer_handle, K_NO_WAIT, K_MSEC(1000 * work_context->params.period));
     } else {
         k_timer_stop(&work_context->timer_handle);
     }


### PR DESCRIPTION
The purpose of this Pull-Request is to fix an issue while changing timer period on Zephyr targets.

The `k_timer_start` function allows to change the `period` of the timer even if it is already running. However, this is not possible if the `duration` is K_FOREVER (not mentioned in Zephyr doc, only in the code).

As a consequence the updates were checked with period `CONFIG_MENDER_CLIENT_AUTHENTICATION_POLL_INTERVAL` instead of `CONFIG_MENDER_CLIENT_UPDATE_POLL_INTERVAL`.