### PR TITLE
Mender device_type, char* → char const*.

### DIFF
--- a/add-ons/inventory/include/mender-inventory-api.h
+++ b/add-ons/inventory/include/mender-inventory-api.h
@@ -35,7 +35,7 @@ extern "C" {
  * @param inventory Mender inventory key/value pairs table, must end with a NULL/NULL element, NULL if not defined
  * @return MENDER_OK if the function succeeds, error code otherwise
  */
-mender_err_t mender_inventory_api_publish_inventory_data(char *artifact_name, char *device_type, mender_keystore_t *inventory);
+mender_err_t mender_inventory_api_publish_inventory_data(char *artifact_name, char const *device_type, mender_keystore_t *inventory);
 
 #endif /* CONFIG_MENDER_CLIENT_ADD_ON_INVENTORY */
 

--- a/add-ons/inventory/src/mender-inventory-api.c
+++ b/add-ons/inventory/src/mender-inventory-api.c
@@ -31,7 +31,7 @@
 #define MENDER_API_PATH_PUT_DEVICE_ATTRIBUTES "/api/devices/v1/inventory/device/attributes"
 
 mender_err_t
-mender_inventory_api_publish_inventory_data(char *artifact_name, char *device_type, mender_keystore_t *inventory) {
+mender_inventory_api_publish_inventory_data(char *artifact_name, char const *device_type, mender_keystore_t *inventory) {
 
     mender_err_t ret;
     cJSON       *item;

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -336,7 +336,7 @@ mender_client_get_artifact_name(void) {
     return mender_client_config.artifact_name;
 }
 
-char *
+char const *
 mender_client_get_device_type(void) {
 
     /* Return device type */

--- a/include/mender-api.h
+++ b/include/mender-api.h
@@ -33,7 +33,7 @@ extern "C" {
 typedef struct {
     mender_keystore_t *identity;      /**< Identity of the device */
     char              *artifact_name; /**< Artifact name */
-    char              *device_type;   /**< Device type */
+    char const        *device_type;   /**< Device type */
     char              *host;          /**< URL of the mender server */
     char              *tenant_token;  /**< Tenant token used to authenticate on the mender server (optional) */
 } mender_api_config_t;

--- a/include/mender-client.h
+++ b/include/mender-client.h
@@ -33,7 +33,7 @@ extern "C" {
 typedef struct {
     mender_keystore_t *identity;                     /**< Identity of the device */
     char              *artifact_name;                /**< Artifact name */
-    char              *device_type;                  /**< Device type */
+    char const        *device_type;                  /**< Device type */
     char              *host;                         /**< URL of the mender server */
     char              *tenant_token;                 /**< Tenant token used to authenticate on the mender server (optional) */
     int32_t            authentication_poll_interval; /**< Authentication poll interval, default is 60 seconds, -1 permits to disable periodic execution */
@@ -77,7 +77,7 @@ char *mender_client_get_artifact_name(void);
  * @brief Retrieve device type from the configuration
  * @return Device type if the function succeeds, NULL otherwise
  */
-char *mender_client_get_device_type(void);
+char const *mender_client_get_device_type(void);
 
 /**
  * @brief Register artifact type


### PR DESCRIPTION
The client is not supposed to change the device type, and if not const this causes a warning when the device_type is defined as a static char const* parameter.