### PR TITLE
ESP-IDF v6+ support

### DIFF
--- a/esp-idf/CMakeLists.txt
+++ b/esp-idf/CMakeLists.txt
@@ -88,10 +88,17 @@ if(CONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT)
 endif()
 
 # Register mender-mcu-client component
+set(mender_requires app_update esp_http_client mbedtls nvs_flash)
+if(IDF_VERSION_MAJOR LESS 6)
+    list(APPEND mender_requires json)
+else()
+    list(APPEND mender_requires espressif__cjson)
+endif()
+
 idf_component_register(
     SRCS ${srcs}
     INCLUDE_DIRS ${incs}
-    REQUIRES app_update esp_http_client json mbedtls nvs_flash
+    REQUIRES ${mender_requires}
 )
 if (CONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT)
     idf_component_optional_requires(PRIVATE espressif__esp_websocket_client esp_event msgpack-c)

--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -258,12 +258,18 @@ menu "Mender Firmware Over-the-Air support"
 
         choice MENDER_PLATFORM_TLS_TYPE
             prompt "Mender platform TLS implementation type"
+            default MENDER_PLATFORM_TLS_TYPE_PSA_CRYPTO if IDF_VERSION_MAJOR >= 6
             default MENDER_PLATFORM_TLS_TYPE_MBEDTLS
             help
                 Specify platform TLS implementation type, select 'weak' to use you own implementation.
+                PSA Crypto is supported on all ESP-IDF versions and required on v6+ (mbedTLS v4).
+                The legacy mbedtls backend is only available on ESP-IDF v5.x.
 
             config MENDER_PLATFORM_TLS_TYPE_MBEDTLS
                 bool "mbedtls"
+                depends on IDF_VERSION_MAJOR < 6
+            config MENDER_PLATFORM_TLS_TYPE_PSA_CRYPTO
+                bool "PSA Crypto"
             config MENDER_PLATFORM_TLS_TYPE_CRYPTOAUTHLIB
                 bool "cryptoauthlib"
             config MENDER_PLATFORM_TLS_TYPE_WEAK
@@ -273,6 +279,7 @@ menu "Mender Firmware Over-the-Air support"
         config MENDER_PLATFORM_TLS_TYPE
             string
             default "generic/mbedtls" if MENDER_PLATFORM_TLS_TYPE_MBEDTLS
+            default "generic/psa_crypto" if MENDER_PLATFORM_TLS_TYPE_PSA_CRYPTO
             default "generic/cryptoauthlib" if MENDER_PLATFORM_TLS_TYPE_CRYPTOAUTHLIB
             default "generic/weak" if MENDER_PLATFORM_TLS_TYPE_WEAK
 
@@ -384,6 +391,33 @@ menu "Mender Firmware Over-the-Air support"
                     bool "ECDSA-P256"
                 config MENDER_PLATFORM_TLS_KEY_TYPE_RSA
                     bool "RSA-3072"
+            endchoice
+
+        endmenu
+
+    endif
+
+    if MENDER_PLATFORM_TLS_TYPE_PSA_CRYPTO
+
+        menu "TLS options (ADVANCED)"
+
+            config MENDER_PLATFORM_TLS_PSA_CRYPTO_SIGNATURE_KEY_ID
+                int "Mender TLS PSA Crypto signature key ID"
+                default 1
+                help
+                    PSA Crypto signature key ID.
+
+            choice MENDER_PLATFORM_TLS_PSA_CRYPTO_KEY_LIFETIME
+                prompt "Mender platform TLS key lifetime"
+                default MENDER_PLATFORM_TLS_KEY_LIFETIME_VOLATILE
+                help
+                    PSA Crypto signature key lifetime.
+                    In case Volatile is selected, private and public keys are saved using mender-storage.
+
+                config MENDER_PLATFORM_TLS_KEY_LIFETIME_PERSISTENT
+                    bool "Persistent"
+                config MENDER_PLATFORM_TLS_KEY_LIFETIME_VOLATILE
+                    bool "Volatile"
             endchoice
 
         endmenu

--- a/esp-idf/idf_component.yml
+++ b/esp-idf/idf_component.yml
@@ -1,0 +1,24 @@
+# @file      idf_component.yml
+# @brief     mender-mcu-client component dependencies
+#
+# Copyright joelguittet and mender-mcu-client contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dependencies:
+  idf: ">=5.0"
+
+  espressif/cjson:
+    version: "^1.7.19"
+    rules:
+      - if: "idf_version >=6.0"

--- a/platform/tls/generic/psa_crypto/src/mender-tls.c
+++ b/platform/tls/generic/psa_crypto/src/mender-tls.c
@@ -138,8 +138,9 @@ mender_tls_init(void) {
 
     psa_status_t status;
 
-    /* Initialize PSA Crypto */
-    if (PSA_SUCCESS != (status = psa_crypto_init())) {
+    /* Initialize PSA Crypto (idempotent on platforms that init PSA at boot) */
+    status = psa_crypto_init();
+    if ((PSA_SUCCESS != status) && (PSA_ERROR_BAD_STATE != status)) {
         mender_log_error("Unable to initialize PSA Crypto (%d)", status);
         return MENDER_FAIL;
     }
@@ -211,6 +212,8 @@ mender_tls_init_authentication_keys(bool recommissioning) {
         }
     }
 #else
+    /* Use the configured persistent key ID */
+    mender_tls_key_id = (mbedtls_svc_key_id_t)CONFIG_MENDER_PLATFORM_TLS_PSA_CRYPTO_SIGNATURE_KEY_ID;
     if (MENDER_OK != (ret = mender_tls_get_authentication_keys(&mender_tls_key_id, &mender_tls_public_key, &mender_tls_public_key_length))) {
 
         /* Generate authentication keys */
@@ -289,7 +292,9 @@ mender_tls_sign_payload(char *payload, char **signature, size_t *signature_lengt
 #endif /* MBEDTLS_ERROR_C */
 
     /* Compute signature of the payload */
-    if (PSA_SUCCESS != (status = psa_sign_message(mender_tls_key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), payload, strlen(payload), sig, sizeof(sig), &sig_len))) {
+    if (PSA_SUCCESS
+        != (status
+            = psa_sign_message(mender_tls_key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), (const uint8_t *)payload, strlen(payload), sig, sizeof(sig), &sig_len))) {
         mender_log_error("Unable to compute signature of the hash (%d)", status);
         return MENDER_FAIL;
     }
@@ -488,6 +493,7 @@ mender_tls_generate_authentication_keys(mbedtls_svc_key_id_t *key_id, unsigned c
 static mender_err_t
 mender_tls_get_authentication_keys(mbedtls_svc_key_id_t *key_id, unsigned char **public_key, size_t *public_key_length) {
 
+    assert(NULL != key_id);
     assert(NULL != public_key);
     assert(NULL != public_key_length);
     psa_status_t status;
@@ -499,6 +505,8 @@ mender_tls_get_authentication_keys(mbedtls_svc_key_id_t *key_id, unsigned char *
     }
     if (PSA_SUCCESS != (status = psa_export_public_key(*key_id, *public_key, MENDER_TLS_PUBLIC_KEY_LENGTH, public_key_length))) {
         mender_log_error("Unable to export public key (%d)", status);
+        free(*public_key);
+        *public_key = NULL;
         return MENDER_FAIL;
     }
 


### PR DESCRIPTION
Adds ESP-IDF v6+ compatibility to `mender-mcu-client` by resolving the `cJSON` dependency change and updating the PSA Crypto TLS backend.

Made `REQUIRES` in `esp-idf/CMakeLists.txt` version-aware:
- If ESP-IDF < v6 - use build-in IDF json
- Else (ESP-IDF >= v6) use `espressif__cjson` managed component

Added `esp-idf/idf_component.yml` that declares:
- Minimum IDF version: >=5.0
- Conditional `espressif/cjson` dependency for IDF v6+

Updated `esp-idf/Kconfig`:
- Use PSA Crypto TLS backend on ESP-IDF v6+
- Restrict mbedtls backend to ESP-IDF v5.x only
- Document that PSA Crypto is required on v6+ due to mbedTLS v4

Updated `platform/tls/generic/psa_crypto/src/mender-tls.c`:
- Detect mbedTLS v4+ and use the key-ID-based PSA API (psa_sign_message, psa_export_public_key, etc.) instead of the handle-based API
- Preserve handle-based code path for mbedTLS v3 (ESP-IDF v5.x)
- Treat psa_crypto_init() returning PSA_ERROR_BAD_STATE as success (PSA may already be initialized at boot)
- Centralize signature key ID access via mender_tls_signature_key_id()

Tested this for both v5.x and v6.x versions of IDF. Seems to work fine but need another pair of eyes to verify. Also been running on my ESP32-P4 testing system over the weekend with no issues. Write any suggestions and questions in the comments and I will get back to you as soon as possible.