### PR TITLE
core: improve client reactivation process to prevent races and possible crashing

### DIFF
--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -469,6 +469,20 @@ mender_client_deactivate(void) {
 
     mender_err_t ret;
 
+    /* Deactivate mender client work FIRST, then the add-ons.
+     *
+     * The add-ons are activated from the client work function itself (running on the work
+     * queue thread) once authentication succeeds - see the "Activate add-ons" block in
+     * mender_client_authentication_work_function(). If we deactivate the add-ons before the
+     * client work, the still-running work thread can activate an add-on (submitting its work)
+     * *after* we just deactivated it. That late work then runs against add-on resources that
+     * mender_client_exit() frees immediately afterwards -> use-after-free (e.g. the inventory
+     * mutex), which crashes when automatic firmware updates are toggled rapidly.
+     *
+     * Draining the client work first guarantees the work thread can no longer activate any
+     * add-on, so the add-on deactivation below reliably stops and drains all add-on work. */
+    mender_scheduler_work_deactivate(mender_client_work_handle);
+
     /* Take mutex used to protect access to the add-ons management list */
     if (MENDER_OK != (ret = mender_scheduler_mutex_take(mender_client_addons_mutex, -1))) {
         mender_log_error("Unable to take mutex");
@@ -486,9 +500,6 @@ mender_client_deactivate(void) {
 
     /* Release mutex used to protect access to the add-ons management list */
     mender_scheduler_mutex_give(mender_client_addons_mutex);
-
-    /* Deactivate mender client work */
-    mender_scheduler_work_deactivate(mender_client_work_handle);
 
     return ret;
 }

--- a/platform/scheduler/freertos/src/mender-scheduler.c
+++ b/platform/scheduler/freertos/src/mender-scheduler.c
@@ -79,12 +79,22 @@ static void mender_scheduler_work_queue_thread(void *arg);
  */
 static QueueHandle_t mender_scheduler_work_queue_handle = NULL;
 
+/**
+ * @brief Semaphore given by the work queue thread right before it terminates, used by
+ *        mender_scheduler_exit() to block until the thread has fully exited
+ */
+static SemaphoreHandle_t mender_scheduler_work_queue_thread_exited = NULL;
+
 mender_err_t
 mender_scheduler_init(void) {
 
     /* Create and start work queue */
     if (NULL == (mender_scheduler_work_queue_handle = xQueueCreate(CONFIG_MENDER_SCHEDULER_WORK_QUEUE_LENGTH, sizeof(mender_scheduler_work_context_t *)))) {
         mender_log_error("Unable to create work queue");
+        return MENDER_FAIL;
+    }
+    if (NULL == (mender_scheduler_work_queue_thread_exited = xSemaphoreCreateBinary())) {
+        mender_log_error("Unable to create work queue thread exit semaphore");
         return MENDER_FAIL;
     }
     if (pdPASS
@@ -95,6 +105,8 @@ mender_scheduler_init(void) {
                        CONFIG_MENDER_SCHEDULER_WORK_QUEUE_PRIORITY,
                        NULL)) {
         mender_log_error("Unable to create work queue thread");
+        vSemaphoreDelete(mender_scheduler_work_queue_thread_exited);
+        mender_scheduler_work_queue_thread_exited = NULL;
         return MENDER_FAIL;
     }
 
@@ -348,6 +360,22 @@ mender_scheduler_exit(void) {
         return MENDER_FAIL;
     }
 
+    /* Block until the work queue thread has fully terminated before returning.
+     * Without this join, the thread may still be draining/executing work (and using the
+     * scheduler globals and the mender client mutexes) while the caller tears those down
+     * and a subsequent mender_scheduler_init() recreates them. That aliases handles between
+     * the old and new instances and corrupts the work queue, which is the race that crashes
+     * the MCU when automatic firmware updates are toggled rapidly. */
+    if (NULL != mender_scheduler_work_queue_thread_exited) {
+        xSemaphoreTake(mender_scheduler_work_queue_thread_exited, portMAX_DELAY);
+        vSemaphoreDelete(mender_scheduler_work_queue_thread_exited);
+        mender_scheduler_work_queue_thread_exited = NULL;
+    }
+
+    /* The work queue itself was deleted by the thread; clear the global so a future init
+     * starts from a clean state and the now-dead thread can never alias it */
+    mender_scheduler_work_queue_handle = NULL;
+
     return MENDER_OK;
 }
 
@@ -379,8 +407,13 @@ mender_scheduler_work_queue_thread(void *arg) {
     (void)arg;
     mender_scheduler_work_context_t *work_context = NULL;
 
+    /* Capture the queue handle locally so the cleanup below never touches a handle that a
+     * newer scheduler instance may have stored in the global after this thread was asked
+     * to exit */
+    QueueHandle_t work_queue_handle = mender_scheduler_work_queue_handle;
+
     /* Handle work to be executed */
-    while (pdPASS == xQueueReceive(mender_scheduler_work_queue_handle, &work_context, portMAX_DELAY)) {
+    while (pdPASS == xQueueReceive(work_queue_handle, &work_context, portMAX_DELAY)) {
 
         /* Check if empty work is received from the work queue, this ask the work queue thread to terminate */
         if (NULL == work_context) {
@@ -403,9 +436,12 @@ mender_scheduler_work_queue_thread(void *arg) {
 
 END:
 
-    /* Release memory */
-    vQueueDelete(mender_scheduler_work_queue_handle);
-    mender_scheduler_work_queue_handle = NULL;
+    /* Release the work queue (using the locally captured handle, never the global) */
+    vQueueDelete(work_queue_handle);
+
+    /* Signal mender_scheduler_exit() that the thread has fully terminated. The caller owns
+     * clearing the global queue handle once it observes this. */
+    xSemaphoreGive(mender_scheduler_work_queue_thread_exited);
 
     /* Terminate work queue thread */
     vTaskDelete(NULL);


### PR DESCRIPTION
Related issue: https://github.com/joelguittet/mender-mcu-client/issues/133.

When OTA updates are toggled rapidly on/off, `mender_client_deactivate()` / `mender_client_exit()` can overlap with a following `mender_client_init()`. That race can crash the MCU (observed on ESP32 / FreeRTOS / ESP-IDF) when a freed or NULL FreeRTOS queue handle reaches `xQueueGenericSend` → `configASSERT(pxQueue)`.

Root causes addressed:
1. Scheduler shutdown is fire-and-forget — `mender_scheduler_exit()` posts a sentinel work item and returns without joining the work-queue thread, so exit can complete while the old worker is still running.
2. Shared globals — work-queue and mutex handles are global; the dying thread’s cleanup and a new `mender_scheduler_init()` can clobber the same handles under a fast off→on.
3. Deactivate ordering — add-ons were deactivated before client work, so the still-running work thread could re-activate an add-on after teardown had started, scheduling work against resources freed in `mender_client_exit()`.

Changes
- Join the FreeRTOS scheduler work-queue thread in mender_scheduler_exit() so the next init cannot race with the old thread.
- Deactivate client work before add-ons so the work thread cannot re-activate an add-on after it was stopped.