### PR TITLE
JWT reauth and HTTP stall guard

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -7,6 +7,7 @@ tests/mocks/esp-idf/include/esp_http_client.h
 tests/mocks/esp-idf/include/esp_log.h
 tests/mocks/esp-idf/include/esp_ota_ops.h
 tests/mocks/esp-idf/include/esp_partition.h
+tests/mocks/esp-idf/include/esp_timer.h
 tests/mocks/esp-idf/include/esp_transport.h
 tests/mocks/esp-idf/include/esp_transport_ws.h
 tests/mocks/esp-idf/include/esp_websocket_client.h
@@ -16,6 +17,7 @@ tests/mocks/esp-idf/src/esp_crt_bundle.c
 tests/mocks/esp-idf/src/esp_err.c
 tests/mocks/esp-idf/src/esp_http_client.c
 tests/mocks/esp-idf/src/esp_ota_ops.c
+tests/mocks/esp-idf/src/esp_timer.c
 tests/mocks/esp-idf/src/esp_websocket_client.c
 tests/mocks/esp-idf/src/nvs.c
 tests/mocks/freertos/include/FreeRTOSConfig.h

--- a/core/src/mender-api.c
+++ b/core/src/mender-api.c
@@ -271,7 +271,10 @@ mender_api_check_for_deployment(char **id, char **artifact_name, char **uri) {
         ret = MENDER_OK;
     } else {
         mender_api_print_response_error(response, status);
-        ret = MENDER_FAIL;
+        /* A 401 means the JWT expired or was revoked server side. Report it distinctly so the
+         * client can go back to the authentication state instead of failing forever: the token
+         * is only ever obtained once, when the client enters MENDER_CLIENT_STATE_AUTHENTICATED */
+        ret = (401 == status) ? MENDER_UNAUTHORIZED : MENDER_FAIL;
     }
 
 END:
@@ -341,7 +344,7 @@ mender_api_publish_deployment_status(char *id, mender_deployment_status_t deploy
         ret = MENDER_OK;
     } else {
         mender_api_print_response_error(response, status);
-        ret = MENDER_FAIL;
+        ret = (401 == status) ? MENDER_UNAUTHORIZED : MENDER_FAIL;
     }
 
 END:

--- a/core/src/mender-client.c
+++ b/core/src/mender-client.c
@@ -698,6 +698,18 @@ mender_client_work_function(void) {
     if (MENDER_CLIENT_STATE_AUTHENTICATED == mender_client_state) {
         /* Perform updates */
         ret = mender_client_update_work_function();
+
+        /* The authentication token is obtained once, when entering the authenticated state, and
+         * the server expires it after a week by default. Without this the client would keep
+         * polling with the stale token until the next reboot, silently stopping updates: go back
+         * to the authentication state and retry at the (shorter) authentication poll interval */
+        if (MENDER_UNAUTHORIZED == ret) {
+            mender_log_warning("Authentication token rejected by the server, reauthenticating");
+            mender_client_state = MENDER_CLIENT_STATE_AUTHENTICATION;
+            if (MENDER_OK != mender_scheduler_work_set_period(mender_client_work_handle, mender_client_config.authentication_poll_interval)) {
+                mender_log_error("Unable to set work period");
+            }
+        }
     }
 
 RELEASE:

--- a/include/mender-utils.h
+++ b/include/mender-utils.h
@@ -42,6 +42,7 @@ typedef enum {
     MENDER_FAIL            = -1, /**< Failure */
     MENDER_NOT_FOUND       = -2, /**< Not found */
     MENDER_NOT_IMPLEMENTED = -3, /**< Not implemented */
+    MENDER_UNAUTHORIZED    = -4, /**< Server rejected the authentication token (HTTP 401) */
 } mender_err_t;
 
 /**

--- a/platform/net/esp-idf/src/mender-http.c
+++ b/platform/net/esp-idf/src/mender-http.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <esp_http_client.h>
 #include <esp_crt_bundle.h>
+#include <esp_timer.h>
 #include "mender-http.h"
 #include "mender-log.h"
 #include "mender-utils.h"
@@ -33,6 +34,14 @@
  * @brief Receive buffer length
  */
 #define MENDER_HTTP_RECV_BUF_LENGTH (512)
+
+/**
+ * @brief Maximum time without receiving any response body data before the request is aborted (ms)
+ * @note  This is an idle timeout, not a total one: it is rearmed on every chunk received, so
+ *        artifact downloads streaming through the same loop are never cut short while they make
+ *        progress
+ */
+#define MENDER_HTTP_STALL_TIMEOUT_MS (60000)
 
 /**
  * @brief Mender HTTP configuration
@@ -143,7 +152,13 @@ mender_http_perform(char                *jwt,
         goto END;
     }
 
-    /* Read data until all have been received */
+    /* Read data until all have been received.
+     * esp_http_client_read() returns 0 both on a socket timeout and on a peer that simply stops
+     * sending mid-body, and the loop below only ends on a complete response, so a stalled server
+     * would otherwise spin here forever - wedging the caller, which is the mender scheduler work
+     * queue thread, with no further log output. Bail out once no data has arrived for
+     * MENDER_HTTP_STALL_TIMEOUT_MS */
+    int64_t last_progress_us = esp_timer_get_time();
     do {
 
         char data[MENDER_HTTP_RECV_BUF_LENGTH];
@@ -154,6 +169,8 @@ mender_http_perform(char                *jwt,
             ret = MENDER_FAIL;
             goto END;
         } else if (read_length > 0) {
+            /* Rearm the stall deadline: the transfer is making progress */
+            last_progress_us = esp_timer_get_time();
             /* Transmit data received to the upper layer */
             if (MENDER_OK != (ret = callback(MENDER_HTTP_EVENT_DATA_RECEIVED, data, (size_t)read_length, params))) {
                 mender_log_error("An error occurred, stop reading data");
@@ -162,6 +179,12 @@ mender_http_perform(char                *jwt,
         } else {
             if ((ECONNRESET == errno) || (ENOTCONN == errno)) {
                 mender_log_error("An error occurred, connection has been closed (errno=%d)", errno);
+                callback(MENDER_HTTP_EVENT_ERROR, NULL, 0, params);
+                ret = MENDER_FAIL;
+                goto END;
+            }
+            if ((esp_timer_get_time() - last_progress_us) > (1000LL * MENDER_HTTP_STALL_TIMEOUT_MS)) {
+                mender_log_error("No response data received for %d ms, aborting request (errno=%d)", MENDER_HTTP_STALL_TIMEOUT_MS, errno);
                 callback(MENDER_HTTP_EVENT_ERROR, NULL, 0, params);
                 ret = MENDER_FAIL;
                 goto END;

--- a/tests/mocks/esp-idf/include/esp_timer.h
+++ b/tests/mocks/esp-idf/include/esp_timer.h
@@ -1,0 +1,8 @@
+#ifndef __ESP_TIMER_H__
+#define __ESP_TIMER_H__
+
+#include <stdint.h>
+
+int64_t esp_timer_get_time(void);
+
+#endif /* __ESP_TIMER_H__ */

--- a/tests/mocks/esp-idf/src/esp_timer.c
+++ b/tests/mocks/esp-idf/src/esp_timer.c
@@ -1,0 +1,6 @@
+#include <esp_timer.h>
+
+int64_t
+esp_timer_get_time(void) {
+    return 0;
+}


### PR DESCRIPTION
## Summary

Two independent fixes for failure modes that permanently disable a long-running
client until it is restarted:

1. the client never renews its authentication token, so it stops working when
   the token expires;
2. a stalled HTTP response spins the read loop forever, wedging the scheduler
   work queue thread.

Both were observed in the field on ESP-IDF.

## 1. The client never reauthenticates after the JWT expires

**Current implementation.** `mender_client_work_function()` drives a one-way
state machine: `INITIALIZATION → AUTHENTICATION → AUTHENTICATED`. The JWT is
obtained exactly once, on the transition into `AUTHENTICATED`, and nothing ever
sets the state back.

**Why it fails.** Mender expires device tokens after `jwt_exp_timeout`, one week
by default. From then on every API call returns HTTP 401,
`mender_api_check_for_deployment()` maps it to `MENDER_FAIL` like any other
error, and the client keeps polling with the dead token indefinitely. Updates
and inventory stop silently - no state change, no distinct log - and the only
recovery is a client restart or a reboot. For a device that simply stays up,
this is a guaranteed failure one week after boot. It also freezes the
server-side "last check-in", which tracks authentication requests.

**Fix.** Add `MENDER_UNAUTHORIZED` and return it from the API layer on 401,
distinct from `MENDER_FAIL` so that a transient network error never discards a
still-valid token. When the update work returns it, the client goes back to
`MENDER_CLIENT_STATE_AUTHENTICATION` and resets the work period to
`authentication_poll_interval`:

```c
if (MENDER_UNAUTHORIZED == ret) {
    mender_log_warning("Authentication token rejected by the server, reauthenticating");
    mender_client_state = MENDER_CLIENT_STATE_AUTHENTICATION;
    mender_scheduler_work_set_period(mender_client_work_handle,
                                     mender_client_config.authentication_poll_interval);
}
```

Recovery needs no new code: the existing authentication branch restores the
update interval once a token is obtained, and `mender_api_perform_authentication()`
already frees the previous token before storing the new one.

## 2. A stalled HTTP response never times out (ESP-IDF platform)

**Current implementation.** The read loop in `mender_http_perform()` exits only
when `esp_http_client_is_complete_data_received()` returns true. A return of 0
from `esp_http_client_read()` is treated as "nothing available yet", and is only
turned into an error for `ECONNRESET` / `ENOTCONN`.

**Why it fails.** A peer that sends headers and then stops - a half-open
connection dropped by NAT, a proxy that abandons the body - makes
`esp_http_client_read()` return 0 with neither of those errnos set. The loop
then never terminates and never logs. The scheduler work queue thread is stuck
permanently, so updates and inventory stop with no error at all; the only hint
is the work's "already pending or executing" notice, which is debug level.

**Fix.** Abort the request once no data at all has been received for
`MENDER_HTTP_STALL_TIMEOUT_MS` (60 s), logging the reason so the failure is
visible, and let the normal retry path handle it. The deadline is *idle* rather
than total - rearmed on every chunk received - so artifact downloads streaming
through the same loop are never cut short while they are making progress.

Only the ESP-IDF platform implementation is touched; the other ports have their
own HTTP layers.