### PR TITLE
platform: net: add new option to allow unsecure urls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ if (CONFIG_MENDER_PLATFORM_TLS_TYPE STREQUAL "generic/mbedtls")
         message(STATUS "Using TLS key type RSA-3072")
     endif()
 endif()
+if (CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT)
+    message(WARNING "Usage of unsecure transport URL http:// or ws:// is not recommended except for debugging")
+endif()
 
 # Definitions
 if (CONFIG_MENDER_SERVER_HOST)

--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -285,9 +285,14 @@ menu "Mender Firmware Over-the-Air support"
 
     endmenu
 
-    if MENDER_PLATFORM_NET_TYPE_DEFAULT
+    menu "Network options (ADVANCED)"
 
-        menu "Network options (ADVANCED)"
+        config MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+            bool "Support unsecure transport URL http:// or ws://"
+            help
+                Allow to use unsecure transport URL http:// or ws://, not recommended except for debugging
+
+        if MENDER_PLATFORM_NET_TYPE_DEFAULT
 
             if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
@@ -342,9 +347,9 @@ menu "Mender Firmware Over-the-Air support"
 
             endif
 
-        endmenu
+        endif
 
-    endif
+    endmenu
 
     if MENDER_PLATFORM_SCHEDULER_TYPE_DEFAULT
 

--- a/platform/net/esp-idf/src/mender-http.c
+++ b/platform/net/esp-idf/src/mender-http.c
@@ -87,7 +87,11 @@ mender_http_perform(char                *jwt,
     char                    *bearer = NULL;
 
     /* Compute URL if required */
-    if ((false == mender_utils_strbeginwith(path, "http://")) && (false == mender_utils_strbeginwith(path, "https://"))) {
+    if ((false == mender_utils_strbeginwith(path, "https://"))
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        && (false == mender_utils_strbeginwith(path, "http://"))
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
+    ) {
         size_t str_length = strlen(mender_http_config.host) + strlen(path) + 1;
         if (NULL == (url = (char *)malloc(str_length))) {
             mender_log_error("Unable to allocate memory");

--- a/platform/net/esp-idf/src/mender-websocket.c
+++ b/platform/net/esp-idf/src/mender-websocket.c
@@ -143,16 +143,12 @@ mender_websocket_connect(
     ((mender_websocket_handle_t *)*handle)->params   = params;
 
     /* Compute URL if required */
-    if ((false == mender_utils_strbeginwith(path, "ws://")) && (false == mender_utils_strbeginwith(path, "wss://"))) {
-        if ((true == mender_utils_strbeginwith(path, "http://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "http://"))) {
-            size_t str_length = strlen(mender_websocket_config.host) - strlen("http://") + strlen("ws://") + strlen(path) + 1;
-            if (NULL == (url = (char *)malloc(str_length))) {
-                mender_log_error("Unable to allocate memory");
-                ret = MENDER_FAIL;
-                goto FAIL;
-            }
-            snprintf(url, str_length, "ws://%s%s", mender_websocket_config.host + strlen("http://"), path);
-        } else if ((true == mender_utils_strbeginwith(path, "https://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "https://"))) {
+    if ((false == mender_utils_strbeginwith(path, "wss://"))
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        && (false == mender_utils_strbeginwith(path, "ws://"))
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
+    ) {
+        if ((true == mender_utils_strbeginwith(path, "https://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "https://"))) {
             size_t str_length = strlen(mender_websocket_config.host) - strlen("https://") + strlen("wss://") + strlen(path) + 1;
             if (NULL == (url = (char *)malloc(str_length))) {
                 mender_log_error("Unable to allocate memory");
@@ -160,6 +156,16 @@ mender_websocket_connect(
                 goto FAIL;
             }
             snprintf(url, str_length, "wss://%s%s", mender_websocket_config.host + strlen("https://"), path);
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        } else if ((true == mender_utils_strbeginwith(path, "http://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "http://"))) {
+            size_t str_length = strlen(mender_websocket_config.host) - strlen("http://") + strlen("ws://") + strlen(path) + 1;
+            if (NULL == (url = (char *)malloc(str_length))) {
+                mender_log_error("Unable to allocate memory");
+                ret = MENDER_FAIL;
+                goto FAIL;
+            }
+            snprintf(url, str_length, "ws://%s%s", mender_websocket_config.host + strlen("http://"), path);
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
         } else {
             size_t str_length = strlen(mender_websocket_config.host) + strlen(path) + 1;
             if (NULL == (url = (char *)malloc(str_length))) {
@@ -181,10 +187,12 @@ mender_websocket_connect(
                                              .reconnect_timeout_ms = CONFIG_MENDER_WEBSOCKET_RECONNECT_TIMEOUT,
                                              .network_timeout_ms   = CONFIG_MENDER_WEBSOCKET_NETWORK_TIMEOUT,
                                              .ping_interval_sec    = CONFIG_MENDER_WEBSOCKET_PING_INTERVAL };
-    if (true == mender_utils_strbeginwith(config.uri, "ws://")) {
-        config.transport = WEBSOCKET_TRANSPORT_OVER_TCP;
-    } else if (true == mender_utils_strbeginwith(config.uri, "wss://")) {
+    if (true == mender_utils_strbeginwith(config.uri, "wss://")) {
         config.transport = WEBSOCKET_TRANSPORT_OVER_SSL;
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+    } else if (true == mender_utils_strbeginwith(config.uri, "ws://")) {
+        config.transport = WEBSOCKET_TRANSPORT_OVER_TCP;
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
     } else {
         config.transport = WEBSOCKET_TRANSPORT_UNKNOWN;
     }

--- a/platform/net/generic/curl/src/mender-http.c
+++ b/platform/net/generic/curl/src/mender-http.c
@@ -102,7 +102,11 @@ mender_http_perform(char                *jwt,
     struct curl_slist *headers         = NULL;
 
     /* Compute URL if required */
-    if ((false == mender_utils_strbeginwith(path, "http://")) && (false == mender_utils_strbeginwith(path, "https://"))) {
+    if ((false == mender_utils_strbeginwith(path, "https://"))
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        && (false == mender_utils_strbeginwith(path, "http://"))
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
+    ) {
         size_t str_length = strlen(mender_http_config.host) + strlen(path) + 1;
         if (NULL == (url = (char *)malloc(str_length))) {
             mender_log_error("Unable to allocate memory");

--- a/platform/net/generic/curl/src/mender-websocket.c
+++ b/platform/net/generic/curl/src/mender-websocket.c
@@ -144,16 +144,12 @@ mender_websocket_connect(
     ((mender_websocket_handle_t *)*handle)->params   = params;
 
     /* Compute URL if required */
-    if ((false == mender_utils_strbeginwith(path, "ws://")) && (false == mender_utils_strbeginwith(path, "wss://"))) {
-        if ((true == mender_utils_strbeginwith(path, "http://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "http://"))) {
-            size_t str_length = strlen(mender_websocket_config.host) - strlen("http://") + strlen("ws://") + strlen(path) + 1;
-            if (NULL == (url = (char *)malloc(str_length))) {
-                mender_log_error("Unable to allocate memory");
-                ret = MENDER_FAIL;
-                goto FAIL;
-            }
-            snprintf(url, str_length, "ws://%s%s", mender_websocket_config.host + strlen("http://"), path);
-        } else if ((true == mender_utils_strbeginwith(path, "https://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "https://"))) {
+    if ((false == mender_utils_strbeginwith(path, "wss://"))
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        && (false == mender_utils_strbeginwith(path, "ws://"))
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
+    ) {
+        if ((true == mender_utils_strbeginwith(path, "https://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "https://"))) {
             size_t str_length = strlen(mender_websocket_config.host) - strlen("https://") + strlen("wss://") + strlen(path) + 1;
             if (NULL == (url = (char *)malloc(str_length))) {
                 mender_log_error("Unable to allocate memory");
@@ -161,6 +157,16 @@ mender_websocket_connect(
                 goto FAIL;
             }
             snprintf(url, str_length, "wss://%s%s", mender_websocket_config.host + strlen("https://"), path);
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        } else if ((true == mender_utils_strbeginwith(path, "http://")) || (true == mender_utils_strbeginwith(mender_websocket_config.host, "http://"))) {
+            size_t str_length = strlen(mender_websocket_config.host) - strlen("http://") + strlen("ws://") + strlen(path) + 1;
+            if (NULL == (url = (char *)malloc(str_length))) {
+                mender_log_error("Unable to allocate memory");
+                ret = MENDER_FAIL;
+                goto FAIL;
+            }
+            snprintf(url, str_length, "ws://%s%s", mender_websocket_config.host + strlen("http://"), path);
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
         } else {
             size_t str_length = strlen(mender_websocket_config.host) + strlen(path) + 1;
             if (NULL == (url = (char *)malloc(str_length))) {

--- a/platform/net/zephyr/src/mender-net.c
+++ b/platform/net/zephyr/src/mender-net.c
@@ -53,8 +53,11 @@ mender_net_get_host_port_url(char *path, char *config_host, char **host, char **
     char *saveptr;
 
     /* Check if the path start with protocol */
-    if ((false == mender_utils_strbeginwith(path, "http://")) && (false == mender_utils_strbeginwith(path, "https://"))
-        && (false == mender_utils_strbeginwith(path, "ws://")) && (false == mender_utils_strbeginwith(path, "wss://"))) {
+    if ((false == mender_utils_strbeginwith(path, "https://")) && (false == mender_utils_strbeginwith(path, "wss://"))
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        && (false == mender_utils_strbeginwith(path, "http://")) && (false == mender_utils_strbeginwith(path, "ws://"))
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
+    ) {
 
         /* Path contain the URL only, retrieve host and port from configuration */
         assert(NULL != url);
@@ -89,10 +92,12 @@ mender_net_get_host_port_url(char *path, char *config_host, char **host, char **
     } else {
         /* Port is not specified */
         *host = strdup(pch1);
-        if ((true == mender_utils_strbeginwith(path, "http://")) || (true == mender_utils_strbeginwith(path, "ws://"))) {
-            *port = strdup("80");
-        } else if ((true == mender_utils_strbeginwith(path, "https://")) || (true == mender_utils_strbeginwith(path, "wss://"))) {
+        if ((true == mender_utils_strbeginwith(path, "https://")) || (true == mender_utils_strbeginwith(path, "wss://"))) {
             *port = strdup("443");
+#ifdef CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+        } else if ((true == mender_utils_strbeginwith(path, "http://")) || (true == mender_utils_strbeginwith(path, "ws://"))) {
+            *port = strdup("80");
+#endif /* CONFIG_MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT */
         }
     }
     if (NULL != url) {

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -315,9 +315,14 @@ if MENDER_MCU_CLIENT
 
     endif
 
-    if MENDER_PLATFORM_NET_TYPE_DEFAULT
+    menu "Network options (ADVANCED)"
 
-        menu "Network options (ADVANCED)"
+        config MENDER_PLATFORM_NET_SUPPORT_UNSECURE_TRANSPORT
+            bool "Support unsecure transport URL http:// or ws://"
+            help
+                Allow to use unsecure transport URL http:// or ws://, not recommended except for debugging
+
+        if MENDER_PLATFORM_NET_TYPE_DEFAULT
 
             config MENDER_NET_CA_CERTIFICATE_TAG_PRIMARY
                 int "Primary CA certificate tag"
@@ -371,9 +376,9 @@ if MENDER_MCU_CLIENT
 
             endif
 
-        endmenu
+        endif
 
-    endif
+    endmenu
 
     if MENDER_PLATFORM_SCHEDULER_TYPE_DEFAULT
 


### PR DESCRIPTION
The purpose of this Pull-Request is to introduce a new option so that unsecure transport URLs is not allowed by default. Activating the option allow to use unsecure URLs, for debugging.