### PR TITLE
platform: storage: zephyr: nvs: allow to choose storage partition

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -54,6 +54,7 @@ tests/mocks/tf-m/src/error.c
 tests/mocks/tf-m/src/tfm_its_api.c
 tests/mocks/tf-m/src/tfm_ps_api.c
 tests/mocks/zephyr/include/zephyr/device.h
+tests/mocks/zephyr/include/zephyr/devicetree.h
 tests/mocks/zephyr/include/zephyr/dfu/flash_img.h
 tests/mocks/zephyr/include/zephyr/dfu/mcuboot.h
 tests/mocks/zephyr/include/zephyr/drivers/flash.h

--- a/platform/storage/zephyr/nvs/src/mender-storage.c
+++ b/platform/storage/zephyr/nvs/src/mender-storage.c
@@ -18,6 +18,7 @@
  */
 
 #include <version.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/flash.h>
 #if (ZEPHYR_VERSION_CODE > ZEPHYR_VERSION(4, 3, 0))
 #include <zephyr/kvss/nvs.h>
@@ -30,7 +31,20 @@
 
 /**
  * @brief NVS storage
+ * @note Default is to use `storage_partition`; It is possible to specify another partition
+ *       using chosen `mender,storage-partition = &custom_partition;` in the device tree
  */
+#if DT_HAS_CHOSEN(mender_storage_partition)
+#define MENDER_STORAGE_DT_NODE DT_CHOSEN(mender_storage_partition)
+#if (ZEPHYR_VERSION_CODE > ZEPHYR_VERSION(4, 3, 0))
+#define MENDER_STORAGE_DEVICE PARTITION_NODE_DEVICE(MENDER_STORAGE_DT_NODE)
+#define MENDER_STORAGE_OFFSET PARTITION_NODE_OFFSET(MENDER_STORAGE_DT_NODE)
+#else
+#define MENDER_STORAGE_DEVICE DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(MENDER_STORAGE_DT_NODE))
+#define MENDER_STORAGE_OFFSET DT_REG_ADDR(MENDER_STORAGE_DT_NODE)
+#endif /* (ZEPHYR_VERSION_CODE > ZEPHYR_VERSION(4, 3, 0)) */
+#define MENDER_STORAGE_SIZE DT_REG_SIZE(MENDER_STORAGE_DT_NODE)
+#else
 #define MENDER_STORAGE_LABEL storage_partition
 #if (ZEPHYR_VERSION_CODE > ZEPHYR_VERSION(4, 3, 0))
 #define MENDER_STORAGE_DEVICE PARTITION_DEVICE(MENDER_STORAGE_LABEL)
@@ -41,6 +55,7 @@
 #define MENDER_STORAGE_OFFSET FIXED_PARTITION_OFFSET(MENDER_STORAGE_LABEL)
 #define MENDER_STORAGE_SIZE   FIXED_PARTITION_SIZE(MENDER_STORAGE_LABEL)
 #endif /* (ZEPHYR_VERSION_CODE > ZEPHYR_VERSION(4, 3, 0)) */
+#endif /* DT_HAS_CHOSEN(mender_storage_partition) */
 
 /**
  * @brief NVS keys

--- a/tests/mocks/zephyr/include/zephyr/devicetree.h
+++ b/tests/mocks/zephyr/include/zephyr/devicetree.h
@@ -1,0 +1,9 @@
+#ifndef __DEVICETREE_H__
+#define __DEVICETREE_H__
+
+#define DT_HAS_CHOSEN(prop) 0
+#define DT_CHOSEN(prop)     NULL
+
+#define DT_REG_SIZE(prop) 0
+
+#endif /* __DEVICETREE_H__ */

--- a/tests/mocks/zephyr/include/zephyr/storage/flash_map.h
+++ b/tests/mocks/zephyr/include/zephyr/storage/flash_map.h
@@ -1,6 +1,9 @@
 #ifndef __FLASH_MAP_H__
 #define __FLASH_MAP_H__
 
+#define PARTITION_NODE_DEVICE(prop) NULL
+#define PARTITION_NODE_OFFSET(prop) 0
+
 #define PARTITION_DEVICE(label) NULL
 #define PARTITION_OFFSET(label) 0
 #define PARTITION_SIZE(label)   0


### PR DESCRIPTION
The purpose of this Pull-Request is to provide a solution to choose storage partition used by the client on Zephyr platforms.