### PR TITLE
platform: storage: psa its/ps: allow to store keys

### DIFF
--- a/platform/storage/generic/psa_its/src/mender-storage.c
+++ b/platform/storage/generic/psa_its/src/mender-storage.c
@@ -24,11 +24,17 @@
 /**
  * @brief Storage UIDs
  */
+#ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY (1)
+#endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY */
+#ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY (2)
+#endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY */
 #ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA
-#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA (1)
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA (3)
 #endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA */
 #ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG
-#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG (2)
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG (4)
 #endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG */
 
 mender_err_t
@@ -41,32 +47,89 @@ mender_storage_init(void) {
 mender_err_t
 mender_storage_set_authentication_keys(unsigned char *private_key, size_t private_key_length, unsigned char *public_key, size_t public_key_length) {
 
-    (void)private_key;
-    (void)private_key_length;
-    (void)public_key;
-    (void)public_key_length;
+    assert(NULL != private_key);
+    assert(NULL != public_key);
+    psa_status_t status;
 
-    /* If using PSA API, the mender-tls implementation uses PSA Crypto to manage keys */
-    return MENDER_NOT_IMPLEMENTED;
+    /* Write keys */
+    if (PSA_SUCCESS != (status = psa_its_set(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY, private_key_length, private_key, PSA_STORAGE_FLAG_NONE))) {
+        mender_log_error("Unable to write authentication keys (%d)", status);
+        return MENDER_FAIL;
+    }
+    if (PSA_SUCCESS != (status = psa_its_set(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY, public_key_length, public_key, PSA_STORAGE_FLAG_NONE))) {
+        mender_log_error("Unable to write authentication keys (%d)", status);
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
 }
 
 mender_err_t
 mender_storage_get_authentication_keys(unsigned char **private_key, size_t *private_key_length, unsigned char **public_key, size_t *public_key_length) {
 
-    (void)private_key;
-    (void)private_key_length;
-    (void)public_key;
-    (void)public_key_length;
+    assert(NULL != private_key);
+    assert(NULL != private_key_length);
+    assert(NULL != public_key);
+    assert(NULL != public_key_length);
+    struct psa_storage_info_t info;
+    psa_status_t              status;
 
-    /* If using PSA API, the mender-tls implementation uses PSA Crypto to manage keys */
-    return MENDER_NOT_IMPLEMENTED;
+    /* Retrieve length of the keys */
+    if (PSA_SUCCESS != (status = psa_its_get_info(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY, &info))) {
+        mender_log_info("Authentication keys are not available");
+        return MENDER_NOT_FOUND;
+    }
+    *private_key_length = info.size;
+    if (PSA_SUCCESS != (status = psa_its_get_info(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY, &info))) {
+        mender_log_info("Authentication keys are not available");
+        return MENDER_NOT_FOUND;
+    }
+    *public_key_length = info.size;
+
+    /* Allocate memory to copy keys */
+    if (NULL == (*private_key = (unsigned char *)malloc(*private_key_length))) {
+        mender_log_error("Unable to allocate memory");
+        return MENDER_FAIL;
+    }
+    if (NULL == (*public_key = (unsigned char *)malloc(*public_key_length))) {
+        mender_log_error("Unable to allocate memory");
+        free(*private_key);
+        *private_key = NULL;
+        return MENDER_FAIL;
+    }
+
+    /* Read keys */
+    if (PSA_SUCCESS != (status = psa_its_get(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY, 0, *private_key_length, *private_key, private_key_length))) {
+        mender_log_error("Unable to read authentication keys");
+        free(*private_key);
+        *private_key = NULL;
+        free(*public_key);
+        *public_key = NULL;
+        return MENDER_FAIL;
+    }
+    if (PSA_SUCCESS != (status = psa_its_get(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY, 0, *public_key_length, *public_key, public_key_length))) {
+        mender_log_error("Unable to read authentication keys");
+        free(*private_key);
+        *private_key = NULL;
+        free(*public_key);
+        *public_key = NULL;
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
 }
 
 mender_err_t
 mender_storage_delete_authentication_keys(void) {
 
-    /* If using PSA API, the mender-tls implementation uses PSA Crypto to manage keys */
-    return MENDER_NOT_IMPLEMENTED;
+    /* Erase keys */
+    if ((PSA_SUCCESS != psa_its_remove(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY))
+        || (PSA_SUCCESS != psa_its_remove(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY))) {
+        mender_log_error("Unable to erase authentication keys");
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
 }
 
 mender_err_t

--- a/platform/storage/generic/psa_ps/src/mender-storage.c
+++ b/platform/storage/generic/psa_ps/src/mender-storage.c
@@ -24,11 +24,17 @@
 /**
  * @brief Storage UIDs
  */
+#ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY (1)
+#endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY */
+#ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY (2)
+#endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY */
 #ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA
-#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA (1)
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA (3)
 #endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA */
 #ifndef CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG
-#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG (2)
+#define CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG (4)
 #endif /* CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG */
 
 mender_err_t
@@ -41,32 +47,89 @@ mender_storage_init(void) {
 mender_err_t
 mender_storage_set_authentication_keys(unsigned char *private_key, size_t private_key_length, unsigned char *public_key, size_t public_key_length) {
 
-    (void)private_key;
-    (void)private_key_length;
-    (void)public_key;
-    (void)public_key_length;
+    assert(NULL != private_key);
+    assert(NULL != public_key);
+    psa_status_t status;
 
-    /* If using PSA API, the mender-tls implementation uses PSA Crypto to manage keys */
-    return MENDER_NOT_IMPLEMENTED;
+    /* Write keys */
+    if (PSA_SUCCESS != (status = psa_ps_set(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY, private_key_length, private_key, PSA_STORAGE_FLAG_NONE))) {
+        mender_log_error("Unable to write authentication keys (%d)", status);
+        return MENDER_FAIL;
+    }
+    if (PSA_SUCCESS != (status = psa_ps_set(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY, public_key_length, public_key, PSA_STORAGE_FLAG_NONE))) {
+        mender_log_error("Unable to write authentication keys (%d)", status);
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
 }
 
 mender_err_t
 mender_storage_get_authentication_keys(unsigned char **private_key, size_t *private_key_length, unsigned char **public_key, size_t *public_key_length) {
 
-    (void)private_key;
-    (void)private_key_length;
-    (void)public_key;
-    (void)public_key_length;
+    assert(NULL != private_key);
+    assert(NULL != private_key_length);
+    assert(NULL != public_key);
+    assert(NULL != public_key_length);
+    struct psa_storage_info_t info;
+    psa_status_t              status;
 
-    /* If using PSA API, the mender-tls implementation uses PSA Crypto to manage keys */
-    return MENDER_NOT_IMPLEMENTED;
+    /* Retrieve length of the keys */
+    if (PSA_SUCCESS != (status = psa_ps_get_info(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY, &info))) {
+        mender_log_info("Authentication keys are not available");
+        return MENDER_NOT_FOUND;
+    }
+    *private_key_length = info.size;
+    if (PSA_SUCCESS != (status = psa_ps_get_info(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY, &info))) {
+        mender_log_info("Authentication keys are not available");
+        return MENDER_NOT_FOUND;
+    }
+    *public_key_length = info.size;
+
+    /* Allocate memory to copy keys */
+    if (NULL == (*private_key = (unsigned char *)malloc(*private_key_length))) {
+        mender_log_error("Unable to allocate memory");
+        return MENDER_FAIL;
+    }
+    if (NULL == (*public_key = (unsigned char *)malloc(*public_key_length))) {
+        mender_log_error("Unable to allocate memory");
+        free(*private_key);
+        *private_key = NULL;
+        return MENDER_FAIL;
+    }
+
+    /* Read keys */
+    if (PSA_SUCCESS != (status = psa_ps_get(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY, 0, *private_key_length, *private_key, private_key_length))) {
+        mender_log_error("Unable to read authentication keys");
+        free(*private_key);
+        *private_key = NULL;
+        free(*public_key);
+        *public_key = NULL;
+        return MENDER_FAIL;
+    }
+    if (PSA_SUCCESS != (status = psa_ps_get(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY, 0, *public_key_length, *public_key, public_key_length))) {
+        mender_log_error("Unable to read authentication keys");
+        free(*private_key);
+        *private_key = NULL;
+        free(*public_key);
+        *public_key = NULL;
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
 }
 
 mender_err_t
 mender_storage_delete_authentication_keys(void) {
 
-    /* If using PSA API, the mender-tls implementation uses PSA Crypto to manage keys */
-    return MENDER_NOT_IMPLEMENTED;
+    /* Erase keys */
+    if ((PSA_SUCCESS != psa_ps_remove(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY))
+        || (PSA_SUCCESS != psa_ps_remove(CONFIG_MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY))) {
+        mender_log_error("Unable to erase authentication keys");
+        return MENDER_FAIL;
+    }
+
+    return MENDER_OK;
 }
 
 mender_err_t

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -254,10 +254,8 @@ if MENDER_MCU_CLIENT
                 select NVS
             config MENDER_PLATFORM_STORAGE_TYPE_PSA_ITS
                 bool "PSA Internal Trusted Storage"
-                depends on BUILD_WITH_TFM
             config MENDER_PLATFORM_STORAGE_TYPE_PSA_PS
                 bool "PSA Protected Storage"
-                depends on BUILD_WITH_TFM
             config MENDER_PLATFORM_STORAGE_TYPE_WEAK
                 bool "weak"
         endchoice
@@ -582,15 +580,27 @@ if MENDER_MCU_CLIENT
 
         menu "Storage options"
 
+            config MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY
+                int "PSA Internal Trusted Storage private key UID"
+                default 1
+                help
+                    PSA Internal Trusted Storage private key UID.
+
+            config MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY
+                int "PSA Internal Trusted Storage public key UID"
+                default 2
+                help
+                    PSA Internal Trusted Storage public key UID.
+
             config MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA
                 int "PSA Internal Trusted Storage deployment data UID"
-                default 1
+                default 3
                 help
                     PSA Internal Trusted Storage deployment data UID.
 
             config MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG
                 int "PSA Internal Trusted Storage device configuration UID"
-                default 2
+                default 4
                 help
                     PSA Internal Trusted Storage device configuration UID.
 
@@ -602,15 +612,27 @@ if MENDER_MCU_CLIENT
 
         menu "Storage options"
 
+            config MENDER_STORAGE_PSA_STORAGE_UID_PRIVATE_KEY
+                int "PSA Protected Storage private key UID"
+                default 1
+                help
+                    PSA Protected Storage private key UID.
+
+            config MENDER_STORAGE_PSA_STORAGE_UID_PUBLIC_KEY
+                int "PSA Protected Storage public key UID"
+                default 2
+                help
+                    PSA Protected Storage public key UID.
+
             config MENDER_STORAGE_PSA_STORAGE_UID_DEPLOYMENT_DATA
                 int "PSA Protected Storage deployment data UID"
-                default 1
+                default 3
                 help
                     PSA Protected Storage deployment data UID.
 
             config MENDER_STORAGE_PSA_STORAGE_UID_DEVICE_CONFIG
                 int "PSA Protected Storage device configuration UID"
-                default 2
+                default 4
                 help
                     PSA Protected Storage device configuration UID.
 


### PR DESCRIPTION
The purpose of this Pull-Request is to add the possibility to store privvate and public keys in the psa-its and psa-ps storage implementations.

This is particularly used when PSA APIs are used without TF-M, but instead with another backend.