### PR TITLE
platform: net: allow to configure http timeout

### DIFF
--- a/esp-idf/Kconfig
+++ b/esp-idf/Kconfig
@@ -294,6 +294,14 @@ menu "Mender Firmware Over-the-Air support"
 
         if MENDER_PLATFORM_NET_TYPE_DEFAULT
 
+            config MENDER_NET_HTTP_REQUEST_TIMEOUT_MS
+                int "HTTP request timeout (milliseconds)"
+                default 60000
+                help
+                    Maximum time without receiving any response body data before the request is aborted (milliseconds)
+                    This is an idle timeout, not a total one: it is rearmed on every chunk received, so artifact
+                    downloads streaming through the same loop are never cut short while they make progress
+
             if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
                 config MENDER_WEBSOCKET_THREAD_STACK_SIZE

--- a/platform/net/esp-idf/src/mender-http.c
+++ b/platform/net/esp-idf/src/mender-http.c
@@ -36,12 +36,13 @@
 #define MENDER_HTTP_RECV_BUF_LENGTH (512)
 
 /**
- * @brief Maximum time without receiving any response body data before the request is aborted (ms)
- * @note  This is an idle timeout, not a total one: it is rearmed on every chunk received, so
- *        artifact downloads streaming through the same loop are never cut short while they make
- *        progress
+ * @brief Maximum time without receiving any response body data before the request is aborted (milliseconds)
+ * @note  This is an idle timeout, not a total one: it is rearmed on every chunk received, so artifact
+ *        downloads streaming through the same loop are never cut short while they make progress
  */
-#define MENDER_HTTP_STALL_TIMEOUT_MS (60000)
+#ifndef CONFIG_MENDER_NET_HTTP_STALL_TIMEOUT_MS
+#define CONFIG_MENDER_NET_HTTP_STALL_TIMEOUT_MS (60000)
+#endif /* CONFIG_MENDER_NET_HTTP_STALL_TIMEOUT_MS */
 
 /**
  * @brief Mender HTTP configuration
@@ -161,7 +162,7 @@ mender_http_perform(char                *jwt,
      * sending mid-body, and the loop below only ends on a complete response, so a stalled server
      * would otherwise spin here forever - wedging the caller, which is the mender scheduler work
      * queue thread, with no further log output. Bail out once no data has arrived for
-     * MENDER_HTTP_STALL_TIMEOUT_MS */
+     * CONFIG_MENDER_NET_HTTP_STALL_TIMEOUT_MS */
     int64_t last_progress_us = esp_timer_get_time();
     do {
 
@@ -187,8 +188,8 @@ mender_http_perform(char                *jwt,
                 ret = MENDER_FAIL;
                 goto END;
             }
-            if ((esp_timer_get_time() - last_progress_us) > (1000LL * MENDER_HTTP_STALL_TIMEOUT_MS)) {
-                mender_log_error("No response data received for %d ms, aborting request (errno=%d)", MENDER_HTTP_STALL_TIMEOUT_MS, errno);
+            if ((esp_timer_get_time() - last_progress_us) > (1000LL * CONFIG_MENDER_NET_HTTP_STALL_TIMEOUT_MS)) {
+                mender_log_error("No response data received for %d ms, aborting request (errno=%d)", CONFIG_MENDER_NET_HTTP_STALL_TIMEOUT_MS, errno);
                 callback(MENDER_HTTP_EVENT_ERROR, NULL, 0, params);
                 ret = MENDER_FAIL;
                 goto END;

--- a/platform/net/generic/curl/src/mender-http.c
+++ b/platform/net/generic/curl/src/mender-http.c
@@ -32,6 +32,15 @@
 #endif /* MENDER_CLIENT_VERSION */
 
 /**
+ * @brief Maximum time to proceed the request before it is aborted (milliseconds)
+ * @note  This is a total timeout: it is armed once when the request is initiated, so it must be
+ *        enough long to perform a whole artifact download
+ */
+#ifndef CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS
+#define CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS (600000)
+#endif /* CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS */
+
+/**
  * @brief User data
  */
 typedef struct {
@@ -136,6 +145,11 @@ mender_http_perform(char                *jwt,
     }
     if (CURLE_OK != (err = curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2))) {
         mender_log_error("Unable to set TLSv1.2 (%s)", curl_easy_strerror(err));
+        ret = MENDER_FAIL;
+        goto END;
+    }
+    if (CURLE_OK != (err = curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS))) {
+        mender_log_error("Unable to set timeout (%s)", curl_easy_strerror(err));
         ret = MENDER_FAIL;
         goto END;
     }

--- a/platform/net/zephyr/src/mender-http.c
+++ b/platform/net/zephyr/src/mender-http.c
@@ -34,9 +34,13 @@
 #define MENDER_HTTP_RECV_BUF_LENGTH (512)
 
 /**
- * @brief Request timeout (milliseconds)
+ * @brief Maximum time to proceed the request before it is aborted (milliseconds)
+ * @note  This is a total timeout: it is armed once when the request is initiated, so it must be
+ *        enough long to perform a whole artifact download
  */
-#define MENDER_HTTP_REQUEST_TIMEOUT (600000)
+#ifndef CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS
+#define CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS (600000)
+#endif /* CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS */
 
 /**
  * @brief Request context
@@ -182,7 +186,7 @@ mender_http_perform(char                *jwt,
     }
 
     /* Perform HTTP request */
-    if (http_client_req(sock, &request, MENDER_HTTP_REQUEST_TIMEOUT, (void *)&request_context) < 0) {
+    if (http_client_req(sock, &request, CONFIG_MENDER_NET_HTTP_REQUEST_TIMEOUT_MS, (void *)&request_context) < 0) {
         mender_log_error("Unable to write data");
         ret = MENDER_FAIL;
         goto END;

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -342,6 +342,14 @@ if MENDER_MCU_CLIENT
                 help
                     Peer verification level for TLS connection.
 
+            config MENDER_NET_HTTP_REQUEST_TIMEOUT_MS
+                int "HTTP request timeout (milliseconds)"
+                default 600000
+                help
+                    Maximum time to proceed the request before it is aborted (milliseconds)
+                    This is a total timeout: it is armed once when the request is initiated, so it must be
+                    enough long to perform a whole artifact download
+
             if MENDER_CLIENT_ADD_ON_TROUBLESHOOT
 
                 config MENDER_WEBSOCKET_THREAD_STACK_SIZE


### PR DESCRIPTION
The purpose of this Pull-Request is to allow configuring HTTP timeouts for variaous platforms: Zephyr, ESP-IDF and curl.