### PR TITLE
platform: add missing required module using esp-idf

### DIFF
--- a/esp-idf/CMakeLists.txt
+++ b/esp-idf/CMakeLists.txt
@@ -88,7 +88,7 @@ if(CONFIG_MENDER_CLIENT_ADD_ON_TROUBLESHOOT)
 endif()
 
 # Register mender-mcu-client component
-set(mender_requires app_update esp_http_client mbedtls nvs_flash)
+set(mender_requires app_update esp_http_client esp_timer mbedtls nvs_flash)
 if(IDF_VERSION_MAJOR LESS 6)
     list(APPEND mender_requires json)
 else()


### PR DESCRIPTION
The purpose of this Pull-Request is to fix a missing required module on ESP-IDF platform.
The regression has been introduced at #132 while introducing ESP-IDF v6.0 support.